### PR TITLE
Flatpak: use Node runtime instead of Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ See [here](https://github.com/m-obeid/Muse/pull/2#issue-3965386248)
 1. Install Flatpak and required runtimes:
 
    ```bash
-   flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49
+   flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49 org.freedesktop.Sdk.Extension.node24//24.08
    ```
 
 2. Clone the repository:

--- a/com.pocoguy.Muse.yaml
+++ b/com.pocoguy.Muse.yaml
@@ -2,6 +2,8 @@ app-id: com.pocoguy.Muse
 runtime: org.gnome.Platform
 runtime-version: '49'
 sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node24
 command: muse
 
 # Allow network access during build for pip downloads
@@ -19,16 +21,13 @@ finish-args:
   - --device=dri
 
 modules:
-  # The Deno JavaScript runtime is required to actually play stuff. It's a dependency of yt-dlp[default].
-  - name: deno
+  # Install Node.js to /app/bin for runtime availability
+  - name: nodejs-runtime
     buildsystem: simple
     build-commands:
-      - unzip -q deno-x86_64-unknown-linux-gnu.zip -d ${FLATPAK_DEST}/bin
-      - chmod +x ${FLATPAK_DEST}/bin/deno
-    sources:
-      - type: file
-        url: https://github.com/denoland/deno/releases/download/v2.6.10/deno-x86_64-unknown-linux-gnu.zip
-        sha256: a7c9d5c1f93bfaabe03c3c0583a8c88caf695db3cec4dea2938440038609f225
+      - install -Dm755 /usr/lib/sdk/node24/bin/node ${FLATPAK_DEST}/bin/node
+      - cp -ra /usr/lib/sdk/node24/lib ${FLATPAK_DEST}/ || true
+    sources: []
 
   - name: python-dependencies
     buildsystem: simple


### PR DESCRIPTION
PR #8 switched the pre-configured JavaScript runtime from Deno to Node, so we also need to bundle Node instead of Deno in the flatpak.

Good thing is there is an official flatpak SDK extension, so we don't have to have architecture-specific downloads URLs.