### PR TITLE
Fix(Discord RPC): use state (artist name) on status display to match Spotify's RPC

### DIFF
--- a/src/player/discord_rpc.py
+++ b/src/player/discord_rpc.py
@@ -299,7 +299,7 @@ class DiscordRPCAdapter:
         details = (title or "Unknown")[:128]
         if len(details) < 2:
             details = details + " "
-        state_text = f"by {artist}"[:128]
+        state_text = f"{artist}"[:128]
         if len(state_text) < 2:
             state_text = state_text + " "
 
@@ -308,6 +308,7 @@ class DiscordRPCAdapter:
             "state": state_text,
             "type": 2,  # LISTENING — only type Vesktop's arRPC reliably
                         # forwards for non-detectable apps.
+            "display_status_type": 1, # uses "state" for status display
         }
 
         small_image = (

--- a/src/player/discord_rpc.py
+++ b/src/player/discord_rpc.py
@@ -370,11 +370,16 @@ class DiscordRPCAdapter:
             "main/screenshots/omori-mixtape.png"
         )
 
+        album = track.get("album", "")
+        if isinstance(album, dict):
+            album = album.get("name", "")
+        album = str(album or "")
+
         thumb = track.get("thumb") or ""
         if thumb.startswith("http"):
             activity["assets"] = {
                 "large_image": thumb,
-                "large_text": (title or "Mixtapes")[:128] or "Mixtapes",
+                "large_text": (album or title or "Mixtapes")[:128] or "Mixtapes",
                 "small_image": small_image,
                 "small_text": "Mixtapes",
             }

--- a/src/player/discord_rpc.py
+++ b/src/player/discord_rpc.py
@@ -13,6 +13,34 @@ DISCORD_APP_ID = "1492500060087255231"
 
 RECONNECT_BACKOFF = [5, 15, 30, 60, 120]
 
+STATUS_DISPLAY_TYPES = {
+    "app_name": 0,
+    "artist": 1,
+    "song_title": 2,
+}
+STATUS_DISPLAY_DEFAULT = "artist"
+
+
+def _get_prefs():
+    from gi.repository import GLib
+    path = os.path.join(GLib.get_user_data_dir(), "muse", "prefs.json")
+    try:
+        if os.path.exists(path):
+            with open(path) as f:
+                return json.load(f)
+    except Exception:
+        pass
+    return {}
+
+
+def get_rpc_enabled():
+    return _get_prefs().get("discord_rpc_enabled", True)
+
+
+def get_status_display_type():
+    return _get_prefs().get("discord_rpc_status_display", STATUS_DISPLAY_DEFAULT)
+
+
 OP_HANDSHAKE = 0
 OP_FRAME = 1
 OP_CLOSE = 2
@@ -67,16 +95,36 @@ class DiscordRPCAdapter:
         self._queue = queue.Queue()
         self._connect_attempt = 0
         self._pid = os.getpid()
+        self.status = "Disconnected"
+        self._enabled = get_rpc_enabled()
 
-        self._worker = threading.Thread(target=self._run, daemon=True)
-        self._worker.start()
-        self._queue.put(("connect", None))
+        if self._enabled:
+            self._worker = threading.Thread(target=self._run, daemon=True)
+            self._worker.start()
+            self._queue.put(("connect", None))
+        else:
+            self._worker = None
+            self.status = "Disabled"
 
     # ── Public API ────────────────────────────────────────────────────────
 
     def update(self):
-        if not self._stopping:
+        if not self._stopping and self._enabled:
             self._queue.put(("update", None))
+
+    def set_enabled(self, enabled):
+        self._enabled = enabled
+        if enabled and self._worker is None:
+            self._stopping = False
+            self._queue = queue.Queue()
+            self.status = "Disconnected"
+            self._worker = threading.Thread(target=self._run, daemon=True)
+            self._worker.start()
+            self._queue.put(("connect", None))
+        elif not enabled and self._worker is not None:
+            self.stop()
+            self._worker = None
+            self.status = "Disabled"
 
     def stop(self):
         self._stopping = True
@@ -171,6 +219,7 @@ class DiscordRPCAdapter:
                 if op is None:
                     raise OSError("no handshake response")
                 self.connected = True
+                self.status = "Connected"
                 self._connect_attempt = 0
                 self._do_update()
                 return
@@ -179,6 +228,7 @@ class DiscordRPCAdapter:
                 self._teardown_transport()
                 continue
         print("[DiscordRPC] no Discord IPC endpoint reachable")
+        self.status = "Disconnected"
         self._schedule_reconnect()
 
     def _schedule_reconnect(self):
@@ -276,6 +326,8 @@ class DiscordRPCAdapter:
                 pass
         self.transport = None
         self.connected = False
+        if self._enabled:
+            self.status = "Disconnected"
 
     # ── Payload ───────────────────────────────────────────────────────────
 
@@ -303,12 +355,14 @@ class DiscordRPCAdapter:
         if len(state_text) < 2:
             state_text = state_text + " "
 
+        display_key = get_status_display_type()
+        display_type = STATUS_DISPLAY_TYPES.get(display_key, 1)
+
         activity = {
             "details": details,
             "state": state_text,
-            "type": 2,  # LISTENING — only type Vesktop's arRPC reliably
-                        # forwards for non-detectable apps.
-            "display_status_type": 1, # uses "state" for status display
+            "type": 2,
+            "status_display_type": display_type,
         }
 
         small_image = (

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -877,6 +877,20 @@ class Player(GObject.Object):
                         track["artist"] = final_artist
                         track["thumb"] = final_thumb
 
+                        # Fetch album if missing (needed for Discord RPC)
+                        if not track.get("album"):
+                            try:
+                                wp = self.client.get_watch_playlist(
+                                    video_id=video_id, limit=1
+                                )
+                                wp_tracks = wp.get("tracks", [])
+                                if wp_tracks and wp_tracks[0].get("album"):
+                                    track["album"] = wp_tracks[0]["album"]
+                                    if getattr(self, "discord_rpc", None):
+                                        self.discord_rpc.update()
+                            except Exception:
+                                pass
+
                 # Check generation again before playing
                 if generation != self.load_generation:
                     print(

--- a/src/ui/expanded_player.py
+++ b/src/ui/expanded_player.py
@@ -152,6 +152,10 @@ class ExpandedPlayer(Gtk.Box):
         a_dl.connect("activate", self._on_download)
         self.ep_action_group.add_action(a_dl)
 
+        a_refresh = Gio.SimpleAction.new("refresh_metadata", None)
+        a_refresh.connect("activate", self._on_refresh_metadata)
+        self.ep_action_group.add_action(a_refresh)
+
         meta_row.append(text_box)
         meta_row.append(self.like_btn)
         main_box.append(meta_row)
@@ -598,6 +602,10 @@ class ExpandedPlayer(Gtk.Box):
         if vid and _online and not self.player.download_manager.is_downloaded(vid):
             action_section.append("Download", "ep.download")
 
+        # Refresh metadata (online only)
+        if vid and _online:
+            action_section.append("Refresh Metadata", "ep.refresh_metadata")
+
         if action_section.get_n_items() > 0:
             self.more_menu_model.append_section(None, action_section)
 
@@ -640,6 +648,47 @@ class ExpandedPlayer(Gtk.Box):
                 f"https://music.youtube.com/watch?v={vid}"
             )
             self._show_toast("Link copied")
+
+    def _on_refresh_metadata(self, action, param):
+        vid = self.player.current_video_id
+        idx = self.player.current_queue_index
+        if not vid or idx < 0 or idx >= len(self.player.queue):
+            return
+        self._show_toast("Refreshing metadata...")
+
+        def _fetch():
+            try:
+                wp = self.player.client.get_watch_playlist(video_id=vid, limit=1)
+                wp_tracks = wp.get("tracks", [])
+                if wp_tracks:
+                    fresh = wp_tracks[0]
+                    track = self.player.queue[idx]
+                    if track.get("videoId") != vid:
+                        return
+                    if fresh.get("title"):
+                        track["title"] = fresh["title"]
+                    if fresh.get("artists"):
+                        track["artists"] = fresh["artists"]
+                        track["artist"] = ", ".join(
+                            a.get("name", "") for a in fresh["artists"] if a
+                        )
+                    if fresh.get("album"):
+                        track["album"] = fresh["album"]
+                    if fresh.get("thumbnail"):
+                        thumbs = fresh["thumbnail"]
+                        if isinstance(thumbs, list) and thumbs:
+                            track["thumb"] = thumbs[-1].get("url", "")
+                            track["thumbnails"] = thumbs
+                    if getattr(self.player, "discord_rpc", None):
+                        self.player.discord_rpc.update()
+                    GLib.idle_add(self._show_toast, "Metadata refreshed")
+                else:
+                    GLib.idle_add(self._show_toast, "No metadata found")
+            except Exception as e:
+                print(f"Refresh metadata error: {e}")
+                GLib.idle_add(self._show_toast, "Failed to refresh metadata")
+
+        threading.Thread(target=_fetch, daemon=True).start()
 
     def _show_toast(self, message):
         root = self.get_root()

--- a/src/ui/pages/search.py
+++ b/src/ui/pages/search.py
@@ -704,6 +704,15 @@ class SearchPage(Adw.Bin):
                     elif author:
                         subtitle = str(author)
 
+                # Append album name if available
+                album_data = item.get("album")
+                if album_data:
+                    album_name = album_data.get("name", "") if isinstance(album_data, dict) else str(album_data)
+                    if album_name and subtitle:
+                        subtitle += f" • {album_name}"
+                    elif album_name:
+                        subtitle = album_name
+
                 # Check for Album type
                 if "type" in item and subtitle:
                     subtitle += f" • {item['type']}"
@@ -786,6 +795,35 @@ class SearchPage(Adw.Bin):
                         args=(album_id, item_type, subtitle_label, self.client),
                         daemon=True,
                     ).start()
+
+            # Fetch missing album name in background for songs
+            vid_for_album = item.get("videoId")
+            has_album = item.get("album")
+            if vid_for_album and not has_album and item.get("resultType") in ("song", "video", None):
+                def _fetch_album(vid, itm, lbl, client):
+                    try:
+                        wp = client.get_watch_playlist(video_id=vid, limit=1)
+                        wp_tracks = wp.get("tracks", [])
+                        if wp_tracks and wp_tracks[0].get("album"):
+                            album = wp_tracks[0]["album"]
+                            album_name = album.get("name", "") if isinstance(album, dict) else str(album)
+                            if album_name:
+                                itm["album"] = album
+                                def _update_label():
+                                    cur = lbl.get_label()
+                                    if cur:
+                                        lbl.set_label(f"{cur} • {album_name}")
+                                    else:
+                                        lbl.set_label(album_name)
+                                    lbl.set_visible(True)
+                                GLib.idle_add(_update_label)
+                    except Exception:
+                        pass
+                threading.Thread(
+                    target=_fetch_album,
+                    args=(vid_for_album, item, subtitle_label, self.client),
+                    daemon=True,
+                ).start()
 
             title_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
             title_box.append(title_label)
@@ -1041,14 +1079,15 @@ class SearchPage(Adw.Bin):
                                 elif "artist" in s_data:
                                     s_artist = s_data["artist"]
 
-                                queue_tracks.append(
-                                    {
-                                        "videoId": s_data["videoId"],
-                                        "title": s_title,
-                                        "artist": s_artist,
-                                        "thumb": s_thumb,
-                                    }
-                                )
+                                qt = {
+                                    "videoId": s_data["videoId"],
+                                    "title": s_title,
+                                    "artist": s_artist,
+                                    "thumb": s_thumb,
+                                }
+                                if s_data.get("album"):
+                                    qt["album"] = s_data["album"]
+                                queue_tracks.append(qt)
 
                                 if s_data.get("videoId") == data.get("videoId"):
                                     start_index = idx

--- a/src/ui/widgets/song_row.py
+++ b/src/ui/widgets/song_row.py
@@ -393,6 +393,59 @@ class SongRowWidget(Gtk.Box):
         if action_section.get_n_items() > 0:
             menu_model.append_section(None, action_section)
 
+        # Refresh metadata
+        if item.video_id and _online:
+            def refresh_metadata_action(action, param):
+                vid = item.video_id
+                if not vid:
+                    return
+                self._show_toast("Refreshing metadata...")
+
+                def _fetch():
+                    try:
+                        wp = self.client.get_watch_playlist(video_id=vid, limit=1)
+                        wp_tracks = wp.get("tracks", [])
+                        if wp_tracks:
+                            fresh = wp_tracks[0]
+                            td = item.track_data
+                            if fresh.get("title"):
+                                td["title"] = fresh["title"]
+                            if fresh.get("artists"):
+                                td["artists"] = fresh["artists"]
+                                td["artist"] = ", ".join(
+                                    a.get("name", "") for a in fresh["artists"] if a
+                                )
+                            if fresh.get("album"):
+                                td["album"] = fresh["album"]
+                            if fresh.get("thumbnail"):
+                                thumbs = fresh["thumbnail"]
+                                if isinstance(thumbs, list) and thumbs:
+                                    td["thumb"] = thumbs[-1].get("url", "")
+                                    td["thumbnails"] = thumbs
+                            # Update queue track if it matches
+                            for t in self.player.queue:
+                                if t.get("videoId") == vid:
+                                    t.update(td)
+                                    break
+                            if getattr(self.player, "discord_rpc", None):
+                                self.player.discord_rpc.update()
+                            GLib.idle_add(self._show_toast, "Metadata refreshed")
+                        else:
+                            GLib.idle_add(self._show_toast, "No metadata found")
+                    except Exception as e:
+                        print(f"Refresh metadata error: {e}")
+                        GLib.idle_add(self._show_toast, "Failed to refresh metadata")
+
+                threading.Thread(target=_fetch, daemon=True).start()
+
+            a_refresh = Gio.SimpleAction.new("refresh_metadata", None)
+            a_refresh.connect("activate", refresh_metadata_action)
+            group.add_action(a_refresh)
+            action_section.append("Refresh Metadata", "row.refresh_metadata")
+
+        if action_section.get_n_items() > 0:
+            menu_model.append_section(None, action_section)
+
         # Clipboard section
         clip_section = Gio.Menu()
         if item.video_id and _online:

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -845,6 +845,78 @@ class MainWindow(Adw.ApplicationWindow):
         offline_row.connect("notify::active", on_offline_toggled)
         app_group.add(offline_row)
 
+        # Discord RPC group
+        from player.discord_rpc import (
+            STATUS_DISPLAY_TYPES,
+            STATUS_DISPLAY_DEFAULT,
+        )
+
+        rpc_group = Adw.PreferencesGroup()
+        rpc_group.set_title("Discord Rich Presence")
+        page.add(rpc_group)
+
+        rpc_adapter = getattr(self.player, "discord_rpc", None)
+
+        # Connection status
+        status_text = rpc_adapter.status if rpc_adapter else "Unavailable"
+        status_row = Adw.ActionRow()
+        status_row.set_title("Connection Status")
+        status_label = Gtk.Label(label=status_text)
+        status_label.set_valign(Gtk.Align.CENTER)
+        status_label.add_css_class("dim-label")
+        status_row.add_suffix(status_label)
+        rpc_group.add(status_row)
+
+        # Enable/disable toggle
+        rpc_enabled_row = Adw.SwitchRow()
+        rpc_enabled_row.set_title("Enable Discord RPC")
+        rpc_enabled_row.set_subtitle(
+            "Show what you're listening to on Discord"
+        )
+        rpc_enabled_row.set_active(_prefs.get("discord_rpc_enabled", True))
+
+        # Status display type
+        display_row = Adw.ComboRow()
+        display_row.set_title("Status Display")
+        display_row.set_subtitle("What appears in the status line under your name")
+        display_keys = list(STATUS_DISPLAY_TYPES.keys())
+        display_labels = ["App Name (Mixtapes)", "Artist", "Song Title"]
+        display_row.set_model(Gtk.StringList.new(display_labels))
+        display_row.set_sensitive(rpc_enabled_row.get_active())
+
+        current_display = _prefs.get("discord_rpc_status_display", STATUS_DISPLAY_DEFAULT)
+        for i, key in enumerate(display_keys):
+            if key == current_display:
+                display_row.set_selected(i)
+                break
+
+        def on_rpc_toggled(switch, pspec):
+            enabled = switch.get_active()
+            _prefs["discord_rpc_enabled"] = enabled
+            os.makedirs(os.path.dirname(_prefs_path), exist_ok=True)
+            with open(_prefs_path, "w") as f:
+                _json.dump(_prefs, f)
+            display_row.set_sensitive(enabled)
+            if rpc_adapter:
+                rpc_adapter.set_enabled(enabled)
+                status_label.set_label(rpc_adapter.status)
+
+        rpc_enabled_row.connect("notify::active", on_rpc_toggled)
+        rpc_group.add(rpc_enabled_row)
+
+        def on_display_changed(row, pspec):
+            idx = row.get_selected()
+            if 0 <= idx < len(display_keys):
+                _prefs["discord_rpc_status_display"] = display_keys[idx]
+                os.makedirs(os.path.dirname(_prefs_path), exist_ok=True)
+                with open(_prefs_path, "w") as f:
+                    _json.dump(_prefs, f)
+                if rpc_adapter and rpc_adapter._enabled:
+                    rpc_adapter.update()
+
+        display_row.connect("notify::selected", on_display_changed)
+        rpc_group.add(display_row)
+
         from api.client import MusicClient
 
         is_authed = MusicClient().is_authenticated()


### PR DESCRIPTION
As addressed in #30 

Looked into making the display use the correct album names, but it seems the tracks don't contain an album field. Don't have enough codebase knowledge to do it well unfortunately.