### PR TITLE
Permissions for Discord RPC on flatpak packaging

### DIFF
--- a/com.pocoguy.Muse.yaml
+++ b/com.pocoguy.Muse.yaml
@@ -20,8 +20,11 @@ finish-args:
   - --share=network
   - --persist=.
   - --device=dri
+  - --device=input
   - --socket=session-bus
   - --filesystem=xdg-music
+  - --filesystem=xdg-run/app/com.discordapp.Discord
+  - --filesystem=xdg-run/discord-ipc-0
 modules:
   - name: nodejs-runtime
     buildsystem: simple

--- a/com.pocoguy.Muse.yaml
+++ b/com.pocoguy.Muse.yaml
@@ -20,7 +20,6 @@ finish-args:
   - --share=network
   - --persist=.
   - --device=dri
-  - --device=input
   - --socket=session-bus
   - --filesystem=xdg-music
   - --filesystem=xdg-run/app/com.discordapp.Discord


### PR DESCRIPTION
This pull request add the following lines on com.pocoguy.Muse.yaml :
```
  - --filesystem=xdg-run/app/com.discordapp.Discord
  - --filesystem=xdg-run/discord-ipc-0
```

This allows for the flatpak packaging of the app to communicate with Discord and display the RPC correctly.

There's a testable build at: https://github.com/leoluniere/Mixtapes/actions/runs/24492182548/artifacts/6466013705