### PR TITLE
Set PulseAudio/PipeWire stream application name as Mixtapes instead of main.py

### DIFF
--- a/src/player/player.py
+++ b/src/player/player.py
@@ -6,7 +6,7 @@ import os
 
 gi.require_version("Gst", "1.0")
 gi.require_version("GstAudio", "1.0")
-from gi.repository import Gst, GstAudio, GObject, GLib, GdkPixbuf
+from gi.repository import Gst, GstAudio, GObject, GLib, GdkPixbuf, GLib
 import glob
 from yt_dlp import YoutubeDL
 from ui.utils import get_high_res_url, get_ytimg_fallbacks
@@ -59,6 +59,7 @@ class Player(GObject.Object):
 
     def __init__(self):
         super().__init__()
+        GLib.set_application_name("Mixtapes")
         Gst.init(None)
         self.client = MusicClient()
         self.player = Gst.ElementFactory.make("playbin", "player")


### PR DESCRIPTION
Before, the GStreamer sets its application name as `main.py`, which shows up as such on the PipeWire client. This change makes sure it sets the name to `Mixtapes`.

Before:
<img width="2529" height="1517" alt="image" src="https://github.com/user-attachments/assets/0ffabb0d-2148-4010-b4e9-08323ea9f2a3" />

After:
<img width="2529" height="1517" alt="image" src="https://github.com/user-attachments/assets/c2738d86-9b73-4b51-b36a-7a51edd01b56" />
