### PR TITLE
Provide track album info in MPRIS metadata, and only load MPRIS/SMTC when first playing

### DIFF
--- a/src/player/mpris.py
+++ b/src/player/mpris.py
@@ -195,6 +195,7 @@ class MuseMprisAdapter(MprisAdapter):
                     "mpris:trackid": "/com/pocoguy/Muse/track/none",
                     "xesam:title": "",
                     "xesam:artist": [],
+                    "xesam:album": "",
                 }
 
             track = self.player.queue[self.player.current_queue_index]
@@ -226,6 +227,11 @@ class MuseMprisAdapter(MprisAdapter):
             safe_id = video_id.replace("-", "_").replace(".", "_")
             if safe_id[0].isdigit():
                 safe_id = "v" + safe_id
+            
+            album = track.get("album", "")
+            if isinstance(album, dict):
+                album = album.get("name", "")
+            album = str(album or "")
 
             m = {
                 "mpris:trackid": f"/com/pocoguy/Muse/track/{safe_id}",
@@ -234,6 +240,7 @@ class MuseMprisAdapter(MprisAdapter):
                 else 0,
                 "xesam:title": track.get("title", "Unknown Title"),
                 "xesam:artist": [artist],
+                "xesam:album": album,
             }
 
             art_url = getattr(self.player, "mpris_art_url", None)

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -132,6 +132,26 @@ class Player(GObject.Object):
         # Timer for progress
         GObject.timeout_add(100, self.update_position)
 
+        # boolean checker if media api (MPRIS or SMTC) is loaded
+        self.media_api_loaded = False
+
+        # Discord Rich Presence (cross-platform; no-op if pypresence missing
+        # or Discord not running).
+        try:
+            self.discord_rpc = DiscordRPCAdapter(self)
+            self.connect("state-changed", self._on_discord_state_changed)
+            self.connect("metadata-changed", self._on_discord_metadata_changed)
+        except Exception as e:
+            print(f"Discord RPC init failed: {e}")
+            self.discord_rpc = None
+
+    def load_media_api(self):
+        "Starts MPRIS or SMTC for Linux or Windows, called once only when player starts playing a track"
+        if self.media_api_loaded:
+            return
+
+        self.media_api_loaded = True
+
         # MPRIS Setup (Linux-only, requires D-Bus)
         if HAS_MPRIS:
             self.mpris_adapter = MuseMprisAdapter(self)
@@ -158,16 +178,6 @@ class Player(GObject.Object):
             except Exception as e:
                 print(f"SMTC init failed: {e}")
                 self.smtc = None
-
-        # Discord Rich Presence (cross-platform; no-op if pypresence missing
-        # or Discord not running).
-        try:
-            self.discord_rpc = DiscordRPCAdapter(self)
-            self.connect("state-changed", self._on_discord_state_changed)
-            self.connect("metadata-changed", self._on_discord_metadata_changed)
-        except Exception as e:
-            print(f"Discord RPC init failed: {e}")
-            self.discord_rpc = None
 
     def _on_discord_state_changed(self, obj, state):
         if getattr(self, "discord_rpc", None):
@@ -521,6 +531,8 @@ class Player(GObject.Object):
 
     def _play_current_index(self):
         if 0 <= self.current_queue_index < len(self.queue):
+            self.load_media_api()
+
             track = self.queue[self.current_queue_index]
             video_id = str(track.get("videoId") or "")
             title = str(track.get("title") or "Unknown")


### PR DESCRIPTION
Changes include providing the album field from the track to MPRIS' `xesam:album` field. Previously, before Discord RPC, tracks didn't have the album information, but now it does, so MPRIS should have the information too.
<img width="401" height="155" alt="image" src="https://github.com/user-attachments/assets/2b10cca9-51d2-4601-b9f2-2d98a9cdede8" />

<img width="404" height="155" alt="image" src="https://github.com/user-attachments/assets/f6dc9316-087f-4721-8757-94b552c7303d" />

\
\
A trivial change, but another change was making sure MPRIS/SMTC only loads when the first track starts playing to avoid this state of MPRIS on app startup:
<img width="344" height="158" alt="image" src="https://github.com/user-attachments/assets/43f9ec2e-0cfa-4983-bb6b-1e0898d1925f" />
However, this state still appears with the changes. It happens when a track is started, then the queue is cleared. The root cause is inside `mpris.py` on `metadata()` method. The sure fix is to provide no trackid, `"mpris:trackid": ""`, instead of `"mpris:trackid": "/com/pocoguy/Muse/track/none"`, but an empty trackid causes these warnings/errors:

```
Couldn't find enough metadata, please implement metadata() or get_stream_title() and get_current_track() methods.`
Couldn't find enough metadata, please implement metadata() or get_stream_title() and get_current_track() methods.`
Couldn't find enough metadata, please implement metadata() or get_stream_title() and get_current_track() methods.`
```

The app still seems to work despite the error, but not sure what the implications are so I'm avoiding it for now. It's a more uncommon case that requires a few steps for that state to happen anyways, so probably not too big of a deal.