### PR TITLE
Chore: add specs for Pyinstaller build, and change AUR PKGBUILD to use Pyinstaller for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ MANIFEST
 #   before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!mixtapes.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ chmod +x start.sh
 ./start.sh
 ```
 
+Or build as binary with Pyinstaller:
+
+```bash
+git clone https://github.com/m-obeid/Mixtapes.git
+cd Mixtapes
+python3 -m venv .venv --system-site-packages
+source .venv/bin/activate
+pip install -r requirements.txt
+pyinstaller mixtapes.spec
+./dist/mixtapes/mixtapes
+```
+
 To update:
 
 ```bash

--- a/aur-package/PKGBUILD
+++ b/aur-package/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Mohamad Obeid <mobeid nine nine nine nine at gmail dot com>
+# Contributor: Keo Ponleou Sok <dev.ponleousk@gmail.com>
 pkgname=mixtapes-git
 pkgver=2026.23.04.0
 pkgrel=1
@@ -7,7 +8,7 @@ arch=('any')
 url="https://github.com/m-obeid/Mixtapes"
 license=('GPL3')
 depends=('python' 'python-gobject' 'gtk4' 'libadwaita' 'webkitgtk-6.0' 'nodejs' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-plugins-ugly' 'yt-dlp' 'yt-dlp-ejs' 'python-requests' 'python-ytmusicapi' 'python-mprisify' 'python-mutagen')
-makedepends=('git')
+makedepends=('git' 'pyinstaller')
 provides=("mixtapes")
 conflicts=("mixtapes")
 source=("${pkgname}::git+https://github.com/m-obeid/Mixtapes.git")
@@ -21,29 +22,25 @@ pkgver() {
 build() {
   cd "$pkgname"
   glib-compile-resources --sourcedir=. src/muse.gresource.xml --target=src/muse.gresource
+  pyinstaller mixtapes.spec --clean --noconfirm
 }
 
 package() {
   cd "$pkgname"
-  
-  # Install application files
-  install -d "$pkgdir/usr/lib/mixtapes"
-  cp -r src "$pkgdir/usr/lib/mixtapes/"
-  cp -r assets "$pkgdir/usr/lib/mixtapes/"
+
+  # build with pyinstaller
+  install -d "$pkgdir/opt/mixtapes"
+  cp -r dist/mixtapes/* "$pkgdir/opt/mixtapes/"
   
   # Install desktop file, metainfo and icons
   install -Dm644 com.pocoguy.Muse.desktop "$pkgdir/usr/share/applications/com.pocoguy.Muse.desktop"
   install -Dm644 com.pocoguy.Muse.metainfo.xml "$pkgdir/usr/share/metainfo/com.pocoguy.Muse.metainfo.xml"
-  install -Dm644 assets/icons/hicolor/scalable/actions/compass2-symbolic.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg"
+  install -Dm644 assets/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg"
 
-  # Launcher
+  # symlink binary from build to exported path bin
   install -d "$pkgdir/usr/bin"
-  cat > "$pkgdir/usr/bin/muse" << 'EOF'
-#!/bin/sh
-exec python /usr/lib/mixtapes/src/main.py "$@"
-EOF
-  chmod +x "$pkgdir/usr/bin/muse"
+  ln -sf /opt/mixtapes/mixtapes "$pkgdir/usr/bin/mixtapes"
   
-  # Also provide 'mixtapes' as an alias
-  ln -s muse "$pkgdir/usr/bin/mixtapes"
+  # Also provide 'muse' as an alias
+  ln -sf /usr/bin/mixtapes "$pkgdir/usr/bin/muse"
 }

--- a/mixtapes.spec
+++ b/mixtapes.spec
@@ -1,0 +1,59 @@
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import collect_all
+
+datas = [('src/muse.gresource', '.'), ('src/ui/style.css', 'ui'), ('assets', 'assets')]
+binaries = []
+hiddenimports = []
+tmp_ret = collect_all('ytmusicapi')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+
+
+a = Analysis(
+    ['src/main.py'],
+    pathex=['src'],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={
+        "gi": {
+            "icons": ["Adwaita"],
+            "themes": ["Adwaita"],
+            "module-versions": {
+                "Gtk": "4.0",
+            },
+        }
+    },
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='mixtapes',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='mixtapes',
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mutagen
 pydbus==0.6.0
 StrEnum==0.4.15
 mprisify @ git+https://gitlab.com/zehkira/mprisify.git@v1.0.0
+pyinstaller

--- a/src/main.py
+++ b/src/main.py
@@ -90,6 +90,11 @@ class MusicApp(Adw.Application):
         # Must be first so it takes priority over system-installed Flatpak icons
         project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         assets_icons = os.path.join(project_root, "assets", "icons")
+
+        # if it doesnt exist, check build root directory for pyinstaller support
+        if not os.path.isdir(assets_icons) and getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+            assets_icons = os.path.join(sys._MEIPASS, "assets", "icons")
+
         if os.path.isdir(assets_icons):
             theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
             theme.set_search_path([assets_icons] + theme.get_search_path())


### PR DESCRIPTION
As discussed in #44 

Also includes a fix for AUR packaging to use the app icon instead of the temporary navigation icon.

Apart from the specs file for Pyinstaller, I also modified the current AUR PKGBUILD itself. If this is unwanted, feel free to revert it, perhaps I could maintain a different aur package using pyinstaller build. Everything seems to work the same on my machine, but please do help test.

Also modified main.py to fallback to using the built directory for Pyinstaller support. Minimal change and should not impact normal application.