### PR TITLE
Chore: use Nuitka to build for AUR packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ chmod +x build.sh
 Run the app with:
 
 ```bash
-./mixtapes
+./src/mixtapes
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ sudo apt install git python3 python3-pip nodejs libgtk-4-dev libadwaita-1-dev li
 
 </details>
 
+#### Option 1: Running from source
+
 ```bash
 git clone https://github.com/m-obeid/Mixtapes.git
 cd Mixtapes
@@ -156,6 +158,23 @@ To update:
 ```bash
 git pull
 pip install -r requirements.txt
+```
+
+#### Option 2: build as binary with Nuitka
+
+Ensure dependencies are installed
+
+```bash
+git clone https://github.com/m-obeid/Mixtapes.git
+cd Mixtapes
+chmod +x build.sh
+./build.sh
+```
+
+Run the app with:
+
+```bash
+./mixtapes
 ```
 
 <details>

--- a/aur-package/PKGBUILD
+++ b/aur-package/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Mohamad Obeid <mobeid nine nine nine nine at gmail dot com>
+# Contributor: Keo Ponleou Sok <dev.ponleousk@gmail.com>
 pkgname=mixtapes-git
 pkgver=2026.26.05.0
 pkgrel=1
@@ -9,7 +10,8 @@ license=('GPL3')
 # Note: webkitgtk-6.0 must come from the 'extra' repository. The CachyOS build
 # is known to malfunction with Mixtapes - see the install hook below.
 depends=('python' 'python-gobject' 'gtk4' 'libadwaita' 'webkitgtk-6.0' 'nodejs' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-plugins-ugly' 'yt-dlp' 'yt-dlp-ejs' 'python-requests' 'python-ytmusicapi' 'python-mprisify' 'python-mutagen')
-makedepends=('git')
+makedepends=('git' 'clang')
+optdepends=('ffmpeg: for downloading music')
 provides=("mixtapes")
 conflicts=("mixtapes")
 install="${pkgname}.install"
@@ -24,15 +26,20 @@ pkgver() {
 build() {
   cd "$pkgname"
   glib-compile-resources --sourcedir=. src/muse.gresource.xml --target=src/muse.gresource
+
+  # setup venv to use pip nuitka (instead of aur)
+  python -m venv --system-site-packages .venv
+  source .venv/bin/activate
+  pip install nuitka
+
+  # build with nuitka
+  nuitka --clang --include-package=ui --include-package=api --include-package=player --include-module=logger --output-filename=mixtapes src/main.py 
+  
+  deactivate
 }
 
 package() {
   cd "$pkgname"
-  
-  # Install application files
-  install -d "$pkgdir/usr/lib/mixtapes"
-  cp -r src "$pkgdir/usr/lib/mixtapes/"
-  cp -r assets "$pkgdir/usr/lib/mixtapes/"
   
   # Install desktop file, metainfo and icons
   install -Dm644 com.pocoguy.Muse.desktop "$pkgdir/usr/share/applications/com.pocoguy.Muse.desktop"
@@ -40,14 +47,10 @@ package() {
   install -Dm644 assets/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg"
   install -Dm644 assets/icons/hicolor/symbolic/apps/com.pocoguy.Muse-symbolic.svg "$pkgdir/usr/share/icons/hicolor/symbolic/apps/com.pocoguy.Muse-symbolic.svg"
 
-  # Launcher
+  # symlink binary from build to exported path bin
   install -d "$pkgdir/usr/bin"
-  cat > "$pkgdir/usr/bin/muse" << 'EOF'
-#!/bin/sh
-exec python /usr/lib/mixtapes/src/main.py "$@"
-EOF
-  chmod +x "$pkgdir/usr/bin/muse"
+  cp mixtapes "$pkgdir/usr/bin/mixtapes"
   
-  # Also provide 'mixtapes' as an alias
-  ln -s muse "$pkgdir/usr/bin/mixtapes"
+  # Also provide 'muse' as an alias
+  ln -sf /usr/bin/mixtapes "$pkgdir/usr/bin/muse"
 }

--- a/aur-package/PKGBUILD
+++ b/aur-package/PKGBUILD
@@ -28,18 +28,39 @@ build() {
   glib-compile-resources --sourcedir=. src/muse.gresource.xml --target=src/muse.gresource
 
   # setup venv to use pip nuitka (instead of aur)
-  python -m venv --system-site-packages .venv
+  python -m venv .venv
   source .venv/bin/activate
   pip install nuitka
-
-  # build with nuitka
-  nuitka --clang --include-package=ui --include-package=api --include-package=player --include-module=logger --output-filename=mixtapes src/main.py 
-  
+  VENV_SITE_PACKAGES=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
   deactivate
+
+  export PYTHONPATH="$VENV_SITE_PACKAGES:$PYTHONPATH"
+  cd src
+  
+  # build with nuitka
+  python -m nuitka --clang \
+  --file-reference-choice=runtime \
+  --include-package=ui \
+  --include-package=api \
+  --include-package=player \
+  --include-module=logger \
+  --output-filename=mixtapes \
+  main.py
 }
 
 package() {
   cd "$pkgname"
+
+  # install data files in the correct runtime directories
+  install -d "$pkgdir/usr/lib/mixtapes"
+  cp -r assets "$pkgdir/usr/lib/mixtapes/"
+
+  install -d "$pkgdir/usr/lib/mixtapes/src"
+  cp src/muse.gresource "$pkgdir/usr/lib/mixtapes/src/"
+  cp src/mixtapes "$pkgdir/usr/lib/mixtapes/src/"
+
+  install -d "$pkgdir/usr/lib/mixtapes/src/ui"
+  cp src/ui/style.css "$pkgdir/usr/lib/mixtapes/src/ui/"
   
   # Install desktop file, metainfo and icons
   install -Dm644 com.pocoguy.Muse.desktop "$pkgdir/usr/share/applications/com.pocoguy.Muse.desktop"
@@ -47,9 +68,9 @@ package() {
   install -Dm644 assets/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.pocoguy.Muse.svg"
   install -Dm644 assets/icons/hicolor/symbolic/apps/com.pocoguy.Muse-symbolic.svg "$pkgdir/usr/share/icons/hicolor/symbolic/apps/com.pocoguy.Muse-symbolic.svg"
 
-  # symlink binary from build to exported path bin
+  # symlink binary to exported path bin
   install -d "$pkgdir/usr/bin"
-  cp mixtapes "$pkgdir/usr/bin/mixtapes"
+  ln -sf /usr/lib/mixtapes/src/mixtapes "$pkgdir/usr/bin/mixtapes"
   
   # Also provide 'muse' as an alias
   ln -sf /usr/bin/mixtapes "$pkgdir/usr/bin/muse"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+python -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install nuitka
+
+# build with nuitka
+nuitka --clang --include-package=ui --include-package=api --include-package=player --include-module=logger --output-filename=mixtapes src/main.py 
+
+deactivate

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/bash
 
-python -m venv --system-site-packages .venv
+python -m venv .venv
 source .venv/bin/activate
 pip install nuitka
+VENV_SITE_PACKAGES=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+deactivate
+
+export PYTHONPATH="$VENV_SITE_PACKAGES:$PYTHONPATH"
+cd src
 
 # build with nuitka
-nuitka --clang --include-package=ui --include-package=api --include-package=player --include-module=logger --output-filename=mixtapes src/main.py 
-
-deactivate
+python -m nuitka --clang \
+--file-reference-choice=runtime \
+--include-package=ui \
+--include-package=api \
+--include-package=player \
+--include-module=logger \
+--output-filename=mixtapes \
+main.py


### PR DESCRIPTION
Continuation from #48. Closed the previous PR because the work is changed to a new branch. Previous PR attempts to build using Pyinstaller, but this changes to use Nuitka instead. This PR is related to #44.

Quick summary on the change from Pyinstaller to Nuitka from #48 's comment:

> Pyinstaller bundles all Python packages and messes with the current AUR packaging dependencies too much. Nuitka builds faster by opting to use system packages, and only bundling source code/packages. Also Nuitka theoretically should improve performance, but I don't notice any improvement personally.