### PR TITLE
Added Preference to Hide Discord RPC on Pause, and improved overall Mpris server handling

### DIFF
--- a/src/player/discord_rpc.py
+++ b/src/player/discord_rpc.py
@@ -51,6 +51,9 @@ def get_small_icon_enabled():
     return _get_prefs().get("discord_rpc_small_icon_enabled", True)
 
 
+def get_hide_pause_enabled():
+    return _get_prefs().get("discord_rpc_hide_pause_enabled", False)
+
 OP_HANDSHAKE = 0
 OP_FRAME = 1
 OP_CLOSE = 2
@@ -344,7 +347,7 @@ class DiscordRPCAdapter:
     def _build_activity(self):
         player = self.player
         state = player.get_state_string()
-        if state == "stopped":
+        if state == "stopped" or (get_hide_pause_enabled() and state == "paused"):
             return None
 
         idx = player.current_queue_index

--- a/src/player/mpris.py
+++ b/src/player/mpris.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
+from typing import override
 import gi
 
 gi.require_version("Gst", "1.0")
 from gi.repository import Gst
 from mprisify.adapters import MprisAdapter
+from mprisify.server import Server
 from mprisify.events import EventAdapter
-from mprisify.base import Position, PlayState, Volume
-from mprisify.enums import LoopStatus
+from mprisify.interfaces.interface import MprisInterface
+from mprisify.base import Position, PlayState, Volume, NAME
+from mprisify.enums import BusType, LoopStatus
 
 
 class MuseMprisAdapter(MprisAdapter):
@@ -254,6 +257,12 @@ class MuseMprisAdapter(MprisAdapter):
             print(f"MPRIS: Error generating metadata: {e}")
             return {}
 
+
+class MuseServer(Server[MprisAdapter, EventAdapter, MprisInterface[MprisAdapter]]):    
+    @override
+    def publish(self, bus_type: BusType = BusType.DEFAULT):
+        if self._publication_token == None:
+            super().publish(bus_type)
 
 class MuseEventAdapter(EventAdapter):
     def emit_all(self):

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -317,8 +317,6 @@ class Player(GObject.Object):
             self.connect("progression", self._on_mpris_progression)
             self.connect("volume-changed", self._on_mpris_volume_changed)
 
-            self.mpris_server.unpublish()
-
         # SMTC Setup (Windows-only)
         if HAS_SMTC:
             try:

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -24,8 +24,7 @@ if sys.platform == "win32":
         pass
 else:
     try:
-        from mprisify.server import Server
-        from player.mpris import MuseMprisAdapter, MuseEventAdapter
+        from player.mpris import MuseMprisAdapter, MuseServer, MuseEventAdapter
         HAS_MPRIS = True
     except ImportError:
         pass
@@ -295,8 +294,8 @@ class Player(GObject.Object):
             print(f"Discord RPC init failed: {e}")
             self.discord_rpc = None
 
-    def load_media_api(self):
-        "Starts MPRIS or SMTC for Linux or Windows, called once only when player starts playing a track"
+    def _load_media_api(self):
+        "Starts MPRIS or SMTC for Linux or Windows, loads once only when _start_playback is called"
         if self.media_api_loaded:
             return
 
@@ -305,7 +304,7 @@ class Player(GObject.Object):
         # MPRIS Setup (Linux-only, requires D-Bus)
         if HAS_MPRIS:
             self.mpris_adapter = MuseMprisAdapter(self)
-            self.mpris_server = Server("Mixtapes", adapter=self.mpris_adapter)
+            self.mpris_server = MuseServer("Mixtapes", adapter=self.mpris_adapter)
             self.mpris_events = MuseEventAdapter(
                 self.mpris_server.root, self.mpris_server.player
             )
@@ -317,6 +316,8 @@ class Player(GObject.Object):
             self.connect("metadata-changed", self._on_mpris_metadata_changed)
             self.connect("progression", self._on_mpris_progression)
             self.connect("volume-changed", self._on_mpris_volume_changed)
+
+            self.mpris_server.unpublish()
 
         # SMTC Setup (Windows-only)
         if HAS_SMTC:
@@ -1013,8 +1014,6 @@ class Player(GObject.Object):
 
     def _play_current_index(self):
         if 0 <= self.current_queue_index < len(self.queue):
-            self.load_media_api()
-
             track = self.queue[self.current_queue_index]
             video_id, title, artist, thumb, like_status = (
                 self._normalize_track_metadata(track)
@@ -1931,6 +1930,11 @@ class Player(GObject.Object):
             except Exception as e:
                 print(f"[PLAYBACK] start failed: {e}")
         threading.Thread(target=_drive, daemon=True).start()
+
+        self._load_media_api()
+        if hasattr(self, "mpris_server"):
+            self.mpris_server.publish()
+
         return False
 
     def play(self):
@@ -1942,6 +1946,9 @@ class Player(GObject.Object):
         self._update_logical_state()
 
     def stop(self):
+        if hasattr(self, "mpris_server"):
+            self.mpris_server.unpublish()
+        
         self.player.set_state(Gst.State.NULL)
         self._is_loading = False
         self._pending_gapless_index = None

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -2200,6 +2200,23 @@ class MainWindow(Adw.ApplicationWindow):
         display_row.connect("notify::selected", on_display_changed)
         rpc_group.add(display_row)
 
+        hide_pause_row = Adw.SwitchRow()
+        hide_pause_row.set_title("Hide on Pause")
+        hide_pause_row.set_subtitle("Hide Discord RPC when music is paused")
+        hide_pause_row.set_active(_prefs.get("discord_rpc_hide_pause_enabled", False))
+        hide_pause_row.set_sensitive(rpc_enabled_row.get_active())
+
+        def on_hide_pause_toggled(switch, pspec):
+            _prefs["discord_rpc_hide_pause_enabled"] = switch.get_active()
+            os.makedirs(os.path.dirname(_prefs_path), exist_ok=True)
+            with open(_prefs_path, "w") as f:
+                _json.dump(_prefs, f)
+            if rpc_adapter and rpc_adapter._enabled:
+                rpc_adapter.update()
+        
+        hide_pause_row.connect("notify::active", on_hide_pause_toggled)
+        rpc_group.add(hide_pause_row)
+
         # Small icon toggle
         small_icon_row = Adw.SwitchRow()
         small_icon_row.set_title("Show Play/Pause Icon")


### PR DESCRIPTION
The PR contains 2 different stuff, but both are small so I thought I'd put them into one PR.

### Hide RPC on pause:

Added a new preference for Discord RPC. A feature I personally wanted, which would also allow the app's RPC behaviour to follow Spotify's. The setting also widely exists in other YTMusic clients like Metrolist and such.

<img width="840" height="570" alt="image" src="https://github.com/user-attachments/assets/34dcba80-7e9e-4ccc-8aef-6f518fd162b5" />

It avoids this state where the music is paused, but the status is always displayed on Discord with the timer incrementing forever

<img width="558" height="201" alt="image" src="https://github.com/user-attachments/assets/c4fe8014-8703-445d-a3bd-c62e74fe7505" />

### Mpris server handling

Somewhat a continuation of #41, improving some stuff I did back then. #41 mentions an issue that I wasn't able to fix then, as described:

> A trivial change, but another change was making sure MPRIS/SMTC only loads when the first track starts playing to avoid this state of MPRIS on app startup:
> <img width="344" height="158" alt="image" src="https://github.com/user-attachments/assets/43f9ec2e-0cfa-4983-bb6b-1e0898d1925f" />
> However, this state still appears with the changes. It happens when a track is started, then the queue is cleared. The root cause is inside `mpris.py` on `metadata()` method. The sure fix is to provide no trackid, `"mpris:trackid": ""`, instead of `"mpris:trackid": "/com/pocoguy/Muse/track/none"`, but an empty trackid causes these warnings/errors:
> The app still seems to work despite the error, but not sure what the implications are so I'm avoiding it for now. It's a more uncommon case that requires a few steps for that state to happen anyways, so probably not too big of a deal.

This PR fixes that issue entirely.