### PR TITLE
Fix: Multiple Bugs with Caching Playlists, such as Mix Playlists and Liked Music

### DIFF
--- a/src/api/client.py
+++ b/src/api/client.py
@@ -2926,7 +2926,7 @@ class MusicClient:
         if not self.is_authenticated():
             return []
         # Liked songs is actually a playlist 'LM'
-        res = self.api.get_liked_songs(limit=limit)
+        res = self.get_playlist("LM", limit=limit)
         return res
 
     def get_charts(self, country="US"):

--- a/src/api/client.py
+++ b/src/api/client.py
@@ -1465,6 +1465,16 @@ class MusicClient:
                     )
                 else:
                     author_str = str(raw_author or "")
+
+                # modify title and description field to a hardcoded value for Liked Music playlist
+                # this modification with a hardcoded value used to exist in `_fetch_playlist_details`
+                # we move it down to the get_playlist level so that the cache and display value doesnt mismatch
+                if playlist_id == "LM":
+                    if "title" in result:
+                        result["title"] = "Your Likes"
+                    if "description" in result:
+                        result["description"] = "Your liked songs from YouTube Music."
+
                 # Store the rich metadata so PlaylistPage can re-render the
                 # full header (year, privacy, author-as-link, etc.) on the
                 # next open before the live fetch completes.

--- a/src/api/client.py
+++ b/src/api/client.py
@@ -2583,7 +2583,11 @@ class MusicClient:
                     playlist_id,
                     data.get("title", ""),
                     author_str,
-                    track_count or len(tracks),
+
+                    # dont use track_count; YouTube Music sometimes give a trackCount value higher than there actually is
+                    # if the value is higher than there actually is, it causes cache regression when there isnt any
+                    len(tracks), 
+                    
                     tracks,
                     meta,
                 )

--- a/src/player/downloads.py
+++ b/src/player/downloads.py
@@ -476,6 +476,13 @@ class DownloadDB:
         the `meta_json` column and should contain fields like `description`,
         `year`, `privacy`, `duration_seconds`, `thumbnails`, and
         `author_raw` (the original artist-dict list)."""
+
+        # RDTMAK playlist are mixes, which always updates and changes
+        # no need to cache, the next fetch will be completely different
+        if playlist_id.startswith("RDTMAK"):
+            print(f"[CLIENT] cache_playlist: reject caching, playlist {playlist_id} is a mix that always changes")
+            return
+
         # Never write the cache when offline — offline responses are
         # themselves reconstructed from the cache, and persisting them
         # would trigger the regression guard for legitimately-shrunken
@@ -487,6 +494,7 @@ class DownloadDB:
                 return
         except Exception:
             pass
+        
         with self._lock:
             conn = self._connect()
             self._ensure_meta_json_column(conn)
@@ -563,6 +571,13 @@ class DownloadDB:
     def get_cached_playlist(self, playlist_id):
         """Get cached playlist data. Returns dict or None. Dict has the
         standard columns plus `tracks` (list) and `meta` (dict)."""
+
+        # RDTMAK playlist are mixes, which always updates and changes
+        # no point getting from cache, the fetched will be completely different
+        if playlist_id.startswith("RDTMAK"):
+            print(f"[CLIENT] get_cached_playlist: reject caching, playlist {playlist_id} is a mix that always changes")
+            return None
+
         with self._lock:
             conn = self._connect()
             self._ensure_meta_json_column(conn)

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -1998,8 +1998,8 @@ class PlaylistPage(Adw.Bin):
 
             elif playlist_id == "LM":
                 data = self.client.get_liked_songs(limit=self.current_limit)
-                title = "Your Likes"
-                description = "Your liked songs from YouTube Music."
+                title = data.get("title", "Unknown Album")
+                description = data.get("description", "")
                 tracks = data.get("tracks", []) if isinstance(data, dict) else data
                 track_count = (
                     data.get("trackCount", len(tracks))

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -2006,8 +2006,12 @@ class PlaylistPage(Adw.Bin):
                     if isinstance(data, dict)
                     else len(tracks)
                 )
-                song_text = "song" if track_count == 1 else "songs"
-                count_str = f"{track_count} {song_text}"
+
+                # track_counts from "trackCount" key can sometimes overcount; a bug from YouTube Music itself
+                # so use length of tracks array
+                song_text = "song" if len(tracks) == 1 else "songs"
+                count_str = f"{len(tracks)} {song_text}"
+
                 year = None
                 author = "You"
                 thumbnails = []
@@ -2036,6 +2040,8 @@ class PlaylistPage(Adw.Bin):
                     track_count = data.get("trackCount", len(tracks))
                     year = data.get("year", "")
 
+                    # track_counts from "trackCount" key can sometimes overcount; a bug from YouTube Music itself
+                    # but we still use it to determine its album_type because they're all determined by YouTube Music
                     if track_count == 1:
                         album_type = "Single"
                     elif 2 <= track_count <= 6:
@@ -2046,8 +2052,12 @@ class PlaylistPage(Adw.Bin):
                     meta_parts = [album_type]
                     if year:
                         meta_parts.append(str(year))
-                    song_text = "song" if track_count == 1 else "songs"
-                    count_str = f"{track_count} {song_text}"
+                    
+                    # track_counts from "trackCount" key can sometimes overcount; a bug from YouTube Music itself
+                    # so use length of tracks array
+                    song_text = "song" if len(tracks) == 1 else "songs"
+                    count_str = f"{len(tracks)} {song_text}"
+
                     meta_parts.append(count_str)
                     count = " • ".join(meta_parts)
 
@@ -2117,8 +2127,10 @@ class PlaylistPage(Adw.Bin):
                         song_text = "Infinite"
                         count_str = "Infinite"
                     else:
-                        song_text = "song" if track_count == 1 else "songs"
-                        count_str = f"{track_count} {song_text}"
+                        # track_counts from "trackCount" key can sometimes overcount; a bug from YouTube Music itself
+                        # so use length of tracks array
+                        song_text = "song" if len(tracks) == 1 else "songs"
+                        count_str = f"{len(tracks)} {song_text}"
 
                     meta_parts = []
                     privacy = data.get("privacy")
@@ -2223,8 +2235,10 @@ class PlaylistPage(Adw.Bin):
                 if "track_count" in locals() and track_count is None:
                     meta2_parts.append("Infinite")
                 else:
+                    # track_counts from "trackCount" key can sometimes overcount; a bug from YouTube Music itself
+                    # so use length of tracks array
                     meta2_parts.append(
-                        f"{locals().get('track_count', 0)} {locals().get('song_text', 'songs')}"
+                        f"{len(locals().get('tracks', []))} {locals().get('song_text', 'songs')}"
                     )
             if duration_str:
                 meta2_parts.append(duration_str)

--- a/src/ui/utils.py
+++ b/src/ui/utils.py
@@ -1396,6 +1396,13 @@ class LikeButton(Gtk.Button):
             if not success:
                 # Revert on failure
                 GLib.idle_add(self.revert, old_status)
+            else:
+                # if disliked, invalidate Liked Music playlist cache
+                # this avoids the regression skip
+                # normal playlists have a similar functionality to invalidate cache when a track is removed
+                if new_status == "INDIFFERENT":
+                    from player.downloads import get_download_db
+                    get_download_db().invalidate_playlist_cache("LM")
 
         thread = threading.Thread(target=do_rate)
         thread.daemon = True


### PR DESCRIPTION
### Liked Music with weird caching scenarios

`_fetch_playlist_details` is the main loader of different playlists, including the Liked Music playlist. There's a few bugs that exists relating to caching. 

One, `get_liked_songs`, which is the method that fetches Liked Music tracks, does not handle caching. This may seem that Liked Music was not intended to be cached, however, there are scenarios that it can become cached through the `_start_background_full_fetch` call when the fetched track list contains less tracks than the `track_count`.

```python
def _fetch_platlist_details():
...
  elif playlist_id == "LM":
      # get_liked_songs doesnt cache
      data = self.client.get_liked_songs(limit=self.current_limit)
...
  elif playlist_id.startswith("MPRE"):
      # get_album does caching         
      data = self.client.get_album(playlist_id)
...
  else:
      # get_playlist does caching
      data = self.client.get_playlist(playlist_id, limit=self.current_limit)
...
  if (
      not is_incremental
      and track_count is not None
      and len(tracks) < track_count
  ):
      if not self.playlist_id.startswith(
          "MPRE"
      ) and not self.playlist_id.startswith("OLAK"):
          # _start_background_full_fetch does caching
          # playlist_id == "LM" may get here
          self._start_background_full_fetch()
```

The fix for this was to make `get_liked_songs` also cache.

Two, YouTube Music itself has a bug where its Liked Music track count is always more than the existing tracks in the playlist. This causes the caching to always think the fetched data is regressed. As implemented, regression skips the cache update, making the playlist cache unable to update. I'm not sure if this bug from YouTube affects other playlists as well, so as a precaution, the cache should store the length of the `tracks` list instead of the possibly incorrect `trackCount` value. Image below shows the incorrect count value:

<img width="1988" height="1391" alt="image" src="https://github.com/user-attachments/assets/33acd598-6d50-4c38-be48-1f43501b3df4" />

Video shows how the Liked Music cache is always outdated and cannot be updated:

https://github.com/user-attachments/assets/ed6e4ddf-3d47-4761-832a-30f57a1b04b5

Three, relating to the incorrect `trackCount` value provided by YouTube Music, this incorrect value sometimes gets flashed in the UI, before reverting back to the correct track list count. This is also fixed. Video below shows the value changing back and forth (from 83 to 93, and back to 83):

https://github.com/user-attachments/assets/16919a30-7a21-4591-bd43-03718e2d68f7

Four, Liked Music playlist regression can also happen when a liked music is removed (aka unliked). Other normal playlists handle this by invalidating the playlist cache if a track was removed from the playlist. However, this invalidation was missing from the unlike action. This PR also fixes it by invaliding when unliked.

### Mix playlist caches even through it always changes

The intended behaviour of mix playlists is that it always changes and updates on every load. This makes caching mix playlists unnecessary since it will always be invalid. Surprisingly, cached mixes also causes some very weird behaviours, where some listed tracks in the loaded mix playlist cannot be interacted, and playing the mix playlist will play from the cached track list instead of the loaded one. This PR fixes this by making caching functions such as `cache_playlist` and `get_cached_playlist` exit when the playlist ID is a mix playlist (with prefix "RDTMAK"). Video shows the weird behaviour of the mix playlist with caching:

https://github.com/user-attachments/assets/4521cddc-30da-445e-b246-156ea8d61cf7


