### PR TITLE
Performance: Optimise navigation view stacks, history page loading, and other fixes

### DIFF
--- a/src/ui/expanded_player.py
+++ b/src/ui/expanded_player.py
@@ -3,6 +3,7 @@ from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gdk, Gio
 from ui.utils import AsyncPicture, LikeButton, MarqueeLabel, show_toast
 from ui.queue_panel import QueuePanel
 from ui.widgets.lyrics_view import LyricsView
+from ui.util_classes import ScrolledWindow
 
 
 class ExpandedPlayer(Gtk.Box):
@@ -49,7 +50,7 @@ class ExpandedPlayer(Gtk.Box):
         # ==========================================
         # PAGE 1: THE PLAYER VIEW
         # ==========================================
-        self.player_scroll = Gtk.ScrolledWindow()
+        self.player_scroll = ScrolledWindow()
         self.player_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.player_scroll.set_propagate_natural_height(True)
 

--- a/src/ui/login.py
+++ b/src/ui/login.py
@@ -6,6 +6,8 @@ gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GObject
 
 from api.client import MusicClient
+from ui.util_classes import ScrolledWindow
+
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -124,7 +126,7 @@ class LoginDialog(Adw.Window):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
 
         # Text Area for headers
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_vexpand(True)
         scrolled.set_min_content_height(300)  # Give it some height
 

--- a/src/ui/pages/all_moods.py
+++ b/src/ui/pages/all_moods.py
@@ -100,5 +100,5 @@ class AllMoodsPage(Adw.Bin):
         if "params" in item:
             root = self.get_root()
             if hasattr(root, "open_category"):
-                nav_title = item.get("title", "Category")
+                nav_title = item.get("title", self.category_title)
                 root.open_category(item["params"], nav_title)

--- a/src/ui/pages/all_moods.py
+++ b/src/ui/pages/all_moods.py
@@ -1,4 +1,5 @@
 from gi.repository import Gtk, Adw, GObject
+from ui.util_classes import ScrolledWindow
 
 class AllMoodsPage(Adw.Bin):
     __gsignals__ = {
@@ -12,7 +13,7 @@ class AllMoodsPage(Adw.Bin):
 
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
-        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled = ScrolledWindow()
         self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
 

--- a/src/ui/pages/artist.py
+++ b/src/ui/pages/artist.py
@@ -7,6 +7,7 @@ from ui.utils import (
     AsyncImage, AsyncPicture, LikeButton, parse_item_metadata,
     attach_playing_highlight,
 )
+from ui.util_classes import ScrolledWindow
 
 
 class ArtistPage(Adw.Bin):
@@ -34,7 +35,7 @@ class ArtistPage(Adw.Bin):
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         # Content Scrolled Window
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
 

--- a/src/ui/pages/base_playlist.py
+++ b/src/ui/pages/base_playlist.py
@@ -5,6 +5,7 @@ from api.client import MusicClient
 from ui.utils import AsyncImage, LikeButton, get_yt_music_link, show_toast
 from ui.models.song import SongItem
 from ui.widgets.song_row import SongRowWidget
+from ui.util_classes import ScrolledWindow
 
 
 class BasePlaylistPage(Adw.Bin):
@@ -25,7 +26,7 @@ class BasePlaylistPage(Adw.Bin):
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         # Content Scrolled Window
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
 
@@ -33,10 +34,6 @@ class BasePlaylistPage(Adw.Bin):
         vadjust = scrolled.get_vadjustment()
         self.vadjust = vadjust
         vadjust.connect("value-changed", self._on_scroll)
-        # Suppress hover-background fades while scrolling — they cause stutter
-        # when the pointer sits over rows that slide past it.
-        from ui.utils import suppress_hover_while_scrolling
-        suppress_hover_while_scrolling(scrolled)
 
         # Clamp for content
         clamp = Adw.Clamp()

--- a/src/ui/pages/category.py
+++ b/src/ui/pages/category.py
@@ -98,7 +98,7 @@ class CategoryPage(Adw.Bin):
         child = self.content_box.get_first_child()
         while child:
             next_child = child.get_next_sibling()
-            if child != self.loading_spinner and child != self.page_title_label:
+            if child != self._loading_wrap and child != self.page_title_label:
                 self.content_box.remove(child)
             child = next_child
 

--- a/src/ui/pages/category.py
+++ b/src/ui/pages/category.py
@@ -4,6 +4,7 @@ import threading
 from api.client import MusicClient
 from ui.utils import AsyncImage, parse_item_metadata
 from ui.widgets.scroll_box import HorizontalScrollBox
+from ui.util_classes import ScrolledWindow
 
 class CategoryPage(Adw.Bin):
     __gsignals__ = {
@@ -26,7 +27,7 @@ class CategoryPage(Adw.Bin):
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         # Scrolled Window
-        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled = ScrolledWindow()
         self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
 

--- a/src/ui/pages/discography.py
+++ b/src/ui/pages/discography.py
@@ -3,6 +3,7 @@ import threading
 import json
 from api.client import MusicClient
 from ui.utils import AsyncImage, parse_item_metadata
+from ui.util_classes import ScrolledWindow
 
 
 class DiscographyPage(Adw.Bin):
@@ -30,7 +31,7 @@ class DiscographyPage(Adw.Bin):
         # Header Bar removed because Adw.NavigationPage handles it
 
         # Scrolled Window
-        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled = ScrolledWindow()
         self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
 

--- a/src/ui/pages/history.py
+++ b/src/ui/pages/history.py
@@ -1,4 +1,5 @@
 import threading
+from typing import Callable
 
 from gi.repository import Gtk, Adw, GLib, Gio, Gdk, GObject, Pango
 
@@ -79,7 +80,7 @@ class HistoryPage(Adw.Bin):
         self._loading_wrap = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         self._loading_wrap.set_valign(Gtk.Align.CENTER)
         self._loading_wrap.set_halign(Gtk.Align.CENTER)
-        self._loading_wrap.set_visible(False)
+        self._loading_wrap.set_visible(True)
         spinner = Adw.Spinner()
         spinner.set_size_request(48, 48)
         self._loading_wrap.append(spinner)
@@ -100,26 +101,30 @@ class HistoryPage(Adw.Bin):
     # ── Loading ────────────────────────────────────────────────────────────
 
     def load(self):
-        """Kick off the initial render. Cached tracks render synchronously
-        so the page isn't blank during a forward-nav transition; the
-        fresh fetch is deferred behind the animation."""
-        self.load_cached()
-        self.refresh_from_server(delay_ms=0)
+        """Kick off the initial render.
 
-    def load_cached(self):
-        """Paint the cached history immediately. Intended to run before
-        the nav animation so the pushed page isn't blank."""
+        Cached tracks are loaded and rendered asynchronously. Once cached rendering completes,
+        a refresh callback is triggered to fetch fresh history from the server.
+        """
+        self._load_cached(async_render=True, async_callback=self.refresh_from_server)
+
+    def _load_cached(self, async_render=False, async_callback: Callable[[], None]=lambda:None):
         if not self.client.is_authenticated():
             self._show_empty("Sign in to view listening history.")
             return
         cached = self.client.get_cached_history() or []
         if cached:
             self._normalize_durations(cached)
-            self._render(cached)
+            self._render(cached, async_render=async_render, async_callback=async_callback)
         else:
             self._clear_sections()
             self.empty_label.set_visible(False)
             self._loading_wrap.set_visible(True)
+
+    def load_cached(self):
+        """Paint the cached history immediately. Intended to run before
+        the nav animation so the pushed page isn't blank."""
+        self._load_cached()
 
     def refresh_from_server(self, delay_ms=0):
         """Fetch fresh history and re-render. `delay_ms` lets callers
@@ -187,7 +192,16 @@ class HistoryPage(Adw.Bin):
                 if real_artists:
                     t["artist"] = ", ".join(real_artists)
 
-    def _render(self, tracks):
+    def _render(self, tracks, async_render=False, async_callback: Callable[[], None]=lambda:None):
+        """Renders the given tracks onto the page.
+
+        If async_render is True, rendering is performed incrementally using GLib.idle_add,
+        processing one group per idle cycle. async_callback (if provided) is called once
+        rendering completes (when idle returns False).
+
+        If async_render is False, all groups are rendered synchronously in a single pass
+        without idle scheduling. async_callback will not be called.
+        """
         self._loading_wrap.set_visible(False)
         self._tracks = tracks
         self._row_imgs = []
@@ -202,19 +216,32 @@ class HistoryPage(Adw.Bin):
 
         # Group by the `played` header YT Music attaches to each track.
         # Tracks that somehow lack a value fall back to "Recently".
-        groups = []  # [(title, [tracks])], preserves YT's order
         by_title = {}
         for idx, t in enumerate(tracks):
             t["_history_index"] = idx
             key = t.get("played") or "Recently"
             if key not in by_title:
-                lst = []
-                by_title[key] = lst
-                groups.append((key, lst))
+                by_title[key] = []
             by_title[key].append(t)
 
-        for title, group_tracks in groups:
-            self.sections_box.append(self._make_section(title, group_tracks))
+        groups = by_title.items()  # [(title, [tracks])], preserves YT's order
+
+        if async_render:
+            groups_iter = iter(groups)
+
+            def _render_by_group():
+                item = next(groups_iter, None)
+                if item is None:
+                    async_callback()
+                    return False
+                title, group_tracks = item
+                self.sections_box.append(self._make_section(title, group_tracks))
+                return True
+
+            GLib.idle_add(_render_by_group)
+        else:
+            for title, group_tracks in groups:
+                self.sections_box.append(self._make_section(title, group_tracks))
 
     def _show_empty(self, msg):
         self._loading_wrap.set_visible(False)

--- a/src/ui/pages/history.py
+++ b/src/ui/pages/history.py
@@ -5,6 +5,7 @@ from gi.repository import Gtk, Adw, GLib, Gio, Gdk, GObject, Pango
 
 from api.client import MusicClient
 from ui.utils import AsyncPicture, LikeButton
+from ui.util_classes import ScrolledWindow
 
 
 class HistoryPage(Adw.Bin):
@@ -35,7 +36,7 @@ class HistoryPage(Adw.Bin):
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.set_child(self.main_box)
 
-        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled = ScrolledWindow()
         self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
 

--- a/src/ui/pages/home.py
+++ b/src/ui/pages/home.py
@@ -9,6 +9,7 @@ from ui.utils import (
     attach_playing_highlight,
 )
 from ui.widgets.scroll_box import HorizontalScrollBox
+from ui.util_classes import ScrolledWindow
 
 
 CARD_SIZE = 160
@@ -338,12 +339,8 @@ class HomePage(Adw.Bin):
         loading_box.append(loading_label)
         self.stack.add_named(loading_box, "loading")
 
-        feed_scroll = Gtk.ScrolledWindow()
+        feed_scroll = ScrolledWindow()
         feed_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        # Suppress hover-background fades while scrolling — they cause stutter
-        # when the pointer sits over cards/rows that slide past it.
-        from ui.utils import suppress_hover_while_scrolling
-        suppress_hover_while_scrolling(feed_scroll)
         feed_clamp = Adw.Clamp()
         feed_clamp.set_maximum_size(1024)
         feed_clamp.set_tightening_threshold(600)

--- a/src/ui/pages/library.py
+++ b/src/ui/pages/library.py
@@ -4,6 +4,7 @@ from gi.repository import Gtk, Adw, GObject, GLib, Gdk, Gio, Pango
 import threading
 from api.client import MusicClient
 from ui.utils import show_toast
+from ui.util_classes import ScrolledWindow
 
 
 LIBRARY_VIEW_MODES = ("list", "grid")
@@ -136,13 +137,9 @@ class LibraryPage(Adw.Bin):
         self.lib_stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)
 
         # Single scrolled window for the whole page
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_vexpand(True)
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        # Suppress hover-background fades while scrolling — they cause stutter
-        # when the pointer sits over cards/rows that slide past it.
-        from ui.utils import suppress_hover_while_scrolling
-        suppress_hover_while_scrolling(scrolled)
 
         clamp = Adw.Clamp()
         # Match PlaylistPage's width so the Library/Explore/Playlist views

--- a/src/ui/pages/mood.py
+++ b/src/ui/pages/mood.py
@@ -2,6 +2,8 @@ from gi.repository import Gtk, Adw, GObject, GLib, Gio, Pango, Gdk
 import threading
 from api.client import MusicClient
 from ui.utils import AsyncImage
+from ui.util_classes import ScrolledWindow
+
 
 class MoodPage(Adw.Bin):
     __gsignals__ = {
@@ -22,7 +24,7 @@ class MoodPage(Adw.Bin):
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         # Scrolled Window
-        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled = ScrolledWindow()
         self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
 

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gdk, Gio, GdkPixbuf
 from api.client import MusicClient
 from ui.utils import AsyncImage, LikeButton, get_yt_music_link, show_toast
 from ui.crop_dialog import ImageCropDialog
+from ui.util_classes import ScrolledWindow
 
 # ── GObject Models ────────────────────────────────────────────────────────────
 
@@ -395,15 +396,11 @@ class PlaylistPage(Adw.Bin):
         # ListView "activate" signal covers keyboard (and double-click).
         self.songs_list.connect("activate", self._on_list_activate)
 
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
         self.vadjust = scrolled.get_vadjustment()
         self.vadjust.connect("value-changed", self._on_scroll)
-        # Suppress hover-background fades while scrolling — they cause stutter
-        # when the pointer sits over rows that slide past it.
-        from ui.utils import suppress_hover_while_scrolling
-        suppress_hover_while_scrolling(scrolled)
 
         clamp = (
             Adw.ClampScrollable() if hasattr(Adw, "ClampScrollable") else Adw.Clamp()

--- a/src/ui/pages/search.py
+++ b/src/ui/pages/search.py
@@ -2,6 +2,7 @@ from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gio, Gdk
 import threading
 from api.client import MusicClient
 from ui.utils import AsyncPicture, LikeButton, parse_item_metadata, attach_playing_highlight
+from ui.util_classes import ScrolledWindow
 
 
 class SearchPage(Adw.Bin):
@@ -23,7 +24,7 @@ class SearchPage(Adw.Bin):
         self.stack.set_vexpand(True)
 
         # 1. Results View
-        results_scrolled = Gtk.ScrolledWindow()
+        results_scrolled = ScrolledWindow()
         results_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
         results_clamp = Adw.Clamp()
@@ -58,7 +59,7 @@ class SearchPage(Adw.Bin):
         self.stack.add_named(loading_box, "loading")
 
         # 3. Explore View (Default)
-        explore_scrolled = Gtk.ScrolledWindow()
+        explore_scrolled = ScrolledWindow()
         explore_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
         # Clamp for Explore

--- a/src/ui/queue.py
+++ b/src/ui/queue.py
@@ -3,6 +3,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GObject, Pango, Gdk, Gio
+from ui.util_classes import ScrolledWindow
 
 
 class QueueItem(GObject.Object):
@@ -181,7 +182,7 @@ class QueuePopover(Gtk.Popover):
 
         self.list_view = Gtk.ListView(model=self.selection_model, factory=factory)
 
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_vexpand(True)
         scrolled.set_child(self.list_view)
         box.append(scrolled)

--- a/src/ui/queue_panel.py
+++ b/src/ui/queue_panel.py
@@ -6,6 +6,7 @@ gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GObject, Pango, Gdk, Gio, GLib
 
 from ui.utils import show_toast
+from ui.util_classes import ScrolledWindow
 
 
 class QueueItem(GObject.Object):
@@ -250,7 +251,7 @@ class QueuePanel(Gtk.Box):
 
         self.list_view = Gtk.ListView(model=self.selection_model, factory=factory)
 
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_vexpand(True)
         scrolled.set_child(self.list_view)
         self.append(scrolled)

--- a/src/ui/util_classes.py
+++ b/src/ui/util_classes.py
@@ -1,0 +1,10 @@
+from gi.repository import Gtk
+from ui.utils import suppress_hover_while_scrolling
+
+
+class ScrolledWindow(Gtk.ScrolledWindow):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Suppress hover-background fades while scrolling — they cause stutter
+        # when the pointer sits over rows that slide past it.
+        suppress_hover_while_scrolling(super())

--- a/src/ui/widgets/add_to_playlist.py
+++ b/src/ui/widgets/add_to_playlist.py
@@ -9,6 +9,7 @@ import threading
 import time
 
 from gi.repository import Gtk, GLib, Gdk
+from ui.util_classes import ScrolledWindow
 
 # CSS provider for this widget — installed once into the default display so
 # every popover instance picks up the styling. Keeps the rounding subtle and
@@ -123,7 +124,7 @@ class AddToPlaylistPopover(Gtk.Popover):
         # ScrolledWindow with a capped height — natural height grows with the
         # list up to max_content_height, then scrolls. Without the cap, a
         # user with 200 playlists got a popover taller than their screen.
-        scrolled = Gtk.ScrolledWindow()
+        scrolled = ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_propagate_natural_height(True)
         scrolled.set_min_content_height(120)

--- a/src/ui/widgets/lyrics_view.py
+++ b/src/ui/widgets/lyrics_view.py
@@ -24,6 +24,7 @@ import time
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Graphene
 
 from ui.widgets.fade_edges_bin import FadeEdgesBin
+from ui.util_classes import ScrolledWindow
 
 
 # Pango's "alpha" attribute takes a 16-bit value where 65535 = fully opaque.
@@ -237,7 +238,7 @@ class LyricsView(Gtk.Box):
         self.stack.add_named(self.status_page, "empty")
 
         # --- Lyrics page ---
-        self.scroller = Gtk.ScrolledWindow()
+        self.scroller = ScrolledWindow()
         self.scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.scroller.set_hexpand(True)
         self.scroller.set_vexpand(True)

--- a/src/ui/widgets/scroll_box.py
+++ b/src/ui/widgets/scroll_box.py
@@ -1,11 +1,12 @@
 from gi.repository import Gtk, GLib
+from ui.util_classes import ScrolledWindow
 
 class HorizontalScrollBox(Gtk.Overlay):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Scrolled Window
-        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled = ScrolledWindow()
         self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER)
         self.scrolled.set_hexpand(True)
         self.scrolled.set_min_content_height(-1)

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -2422,6 +2422,39 @@ class MainWindow(Adw.ApplicationWindow):
         self._avatar_channel_btn.set_sensitive(False)
 
     def init_pages(self):
+
+        # patching Adw.NavigationView's push() to not push into the same page as the current visible page
+        # takes the original push() function, and replaces it with additional checks before calling the original push() function
+        if not getattr(Adw.NavigationView, '_push_patched', False):
+            original_push = Adw.NavigationView.push
+
+            # if both pages have tags, the patch_push checks if the tags between the visible page and the page to push
+            # if the tags are the same, then no push is called
+            #
+            # if tag checks is invalid, then the patch_push checkes the title
+            # if titles are the same, then no push is called
+            def patch_push(self, page):
+                current = self.get_visible_page()
+
+                if current is None:
+                    original_push(self, page)
+                    return
+                
+                current_tag = current.get_tag()
+                page_tag = page.get_tag()
+                if current_tag is not None and page_tag is not None and current_tag != page_tag:
+                    original_push(self, page)
+                    return
+
+                current_title = current.get_title()
+                page_title = page.get_title()
+                
+                if current_title != page_title:
+                    original_push(self, page)
+
+            Adw.NavigationView.push = patch_push
+            Adw.NavigationView._push_patched = True
+    
         # PlaylistPage imported at top level now
 
         # Create Pages

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -1411,15 +1411,13 @@ class MainWindow(Adw.ApplicationWindow):
         page = HistoryPage(self.player)
         if getattr(self, "_is_compact", False):
             page.set_compact_mode(True)
-        # Paint cached rows BEFORE the push so the pushed page arrives
-        # already populated — otherwise the forward-nav slide shows a
-        # blank surface for the 350ms until the fresh fetch lands.
-        page.load_cached()
         nav_page = Adw.NavigationPage(child=page, title="Listening History")
+
+        def _on_shown(p):
+            page.load()
+
+        nav_page.connect("shown", _on_shown)
         nav.push(nav_page)
-        # Fresh fetch runs after the transition so it doesn't compete
-        # for frame time with the slide animation.
-        page.refresh_from_server(delay_ms=350)
 
     def _open_downloads_from_menu(self):
         """Push the Downloads PlaylistPage onto the visible tab's nav
@@ -1436,6 +1434,11 @@ class MainWindow(Adw.ApplicationWindow):
         if getattr(self, "_is_compact", False):
             page.set_compact_mode(True)
         nav_page = Adw.NavigationPage(child=page, title="Downloaded Songs")
+
+        def _on_shown(page):
+            threading.Thread(target=_fetch, daemon=True).start()
+
+        nav_page.connect("shown", _on_shown)
         nav.push(nav_page)
         page.stack.set_visible_child_name("loading")
 
@@ -1464,8 +1467,6 @@ class MainWindow(Adw.ApplicationWindow):
                     t["duration"] = f"{dur // 60}:{dur % 60:02d}"
                 tracks.append(t)
             GLib.idle_add(self._fill_downloads_page, page, tracks)
-
-        threading.Thread(target=_fetch, daemon=True).start()
 
     def _fill_downloads_page(self, page, tracks):
         page.original_tracks = tracks
@@ -2642,11 +2643,14 @@ class MainWindow(Adw.ApplicationWindow):
         # Adw.NavigationPage expects a child widget.
         nav_page = Adw.NavigationPage(child=playlist_page, title="Playlist")
 
+        # Load data
+        def _on_shown(page):
+            playlist_page.load_playlist(playlist_id, initial_data)
+
+        nav_page.connect("shown", _on_shown)
+
         # Push to stack
         active_nav.push(nav_page)
-
-        # Load data
-        playlist_page.load_playlist(playlist_id, initial_data)
 
         # Connect title change signal
         playlist_page.connect(

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -2434,27 +2434,29 @@ class MainWindow(Adw.ApplicationWindow):
             # if tag checks is invalid, then the patch_push checkes the title
             # if titles are the same, then no push is called
             def patch_push(self, page):
+                def tag_diff(page_a, page_b) -> bool:
+                    tag_a = page_a.get_tag()
+                    tag_b = page_b.get_tag()
+                    return tag_a != None and tag_b != None and tag_a != tag_b
+                
+                def title_match(page_a, page_b) -> bool:
+                    title_a = page_a.get_title()
+                    title_b = page_b.get_title()
+                    return title_a == title_b
+
                 current = self.get_visible_page()
 
                 if current is None:
                     original_push(self, page)
                     return
                 
-                current_tag = current.get_tag()
-                page_tag = page.get_tag()
-                if current_tag is not None and page_tag is not None and current_tag != page_tag:
+                if tag_diff(current, page) or not title_match(current, page):
                     original_push(self, page)
                     return
 
-                current_title = current.get_title()
-                page_title = page.get_title()
-                
-                if current_title != page_title:
-                    original_push(self, page)
-
             Adw.NavigationView.push = patch_push
             Adw.NavigationView._push_patched = True
-    
+
         # PlaylistPage imported at top level now
 
         # Create Pages
@@ -2471,6 +2473,29 @@ class MainWindow(Adw.ApplicationWindow):
 
             # Connect to page changes to update Back Button
             nav_view.connect("notify::visible-page", self.update_back_button_visibility)
+
+            def on_push(nav_view):
+                def tag_match(page_a, page_b) -> bool:
+                    tag_a = page_a.get_tag()
+                    tag_b = page_b.get_tag()
+                    return tag_a != None and tag_b != None and tag_a == tag_b
+                
+                def title_match(page_a, page_b) -> bool:
+                    title_a = page_a.get_title()
+                    title_b = page_b.get_title()
+                    return title_a == title_b
+
+                stack = list(nav_view.get_navigation_stack())
+                current_page = nav_view.get_visible_page()
+
+                # just removing the first matching page should be enough 
+                # because there shouldnt be more than one that exists in the current stack
+                for i, p in enumerate(stack[:max(len(stack)-1, 0)]):
+                    if tag_match(p, current_page) or title_match(p, current_page):
+                        nav_view.replace(stack[:i] + stack[i+1:])
+                        return
+
+            nav_view.connect("pushed", on_push)
 
             return nav_view
 

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -2674,7 +2674,7 @@ class MainWindow(Adw.ApplicationWindow):
         # PlaylistPage already has a ToolbarView/Header internally.
         # Adw.NavigationView expects Adw.NavigationPage.
         # Adw.NavigationPage expects a child widget.
-        nav_page = Adw.NavigationPage(child=playlist_page, title="Playlist")
+        nav_page = Adw.NavigationPage(child=playlist_page, title=f"Playlist_{playlist_id}")
 
         # Load data
         def _on_shown(page):
@@ -2737,7 +2737,7 @@ class MainWindow(Adw.ApplicationWindow):
         artist_page = ArtistPage(self.player, self.open_playlist)
 
         nav_page = Adw.NavigationPage(
-            child=artist_page, title=initial_name if initial_name else "Artist"
+            child=artist_page, title=initial_name if initial_name else f"Artist_{channel_id}"
         )
 
         active_nav.push(nav_page)

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -9,6 +9,8 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Gtk, Gdk, Adw, GObject, Gio, GLib, Pango
 from player.player import Player
+from ui.util_classes import ScrolledWindow
+
 
 HAS_TRAY = False
 if sys.platform == "win32":
@@ -336,7 +338,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._dl_popover = Gtk.Popover()
         self._dl_popover.set_size_request(300, -1)
         self._dl_popover.set_parent(self._download_progress_btn)
-        dl_scroll = Gtk.ScrolledWindow()
+        dl_scroll = ScrolledWindow()
         dl_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         dl_scroll.set_max_content_height(400)
         dl_scroll.set_propagate_natural_height(True)
@@ -427,7 +429,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.main_stack.set_transition_duration(300)
 
         # Main Content Area (Scrolled Browser)
-        self.content_bin = Gtk.ScrolledWindow()
+        self.content_bin = ScrolledWindow()
         self.content_bin.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER)
         self.content_bin.set_child(self.view_stack)
 


### PR DESCRIPTION
~Will write a full description later,~ TLDR:
- optimised history page loading with asynchronous rendering
- fix category page accidentally removing the loading circle on loading
- allow navigation page pushes animation to finish before loading the page (fix animation stutters)
- optimised navigation view stack to not add duplicate pages and remove duplicate pages
- apply the `suppress_hover_while_scrolling()` on all `Gtk.ScrolledWindow` objects

This mostly addresses my comment in #44:
> the hover fix seems to work well, but I notice it hasn't been implemented on the explore, search and artist pages, queue list, and preference window
>
> there is also some stutter when opening playlist with tracks compared to a playlist without any tracks. I will try to look into that

~PR is not finished yet, planning to work on graceful shutdown by joining the threads.~ Memory leak issues also relate to threads, so this will probably be moved to that PR.

# Navigation Push Animations

Before, the navigation push animations stutters due to the number of elements the page had to load. This is fixed by delaying loading of the elements after the animation is finished. The fix is also accommodated by a more optimised history page loading for less stutters. Other fixes to make this implementation look better includes fixing the loading circle in the category page and history page. Before, the loading circles for these two pages exists, but were accidentally removed or hidden. Videos below show the animation stutter and fix.

### Before:

https://github.com/user-attachments/assets/50e264fd-f27e-40b7-8daa-8969c586800a

### After:

https://github.com/user-attachments/assets/f2f0e2a4-9b2c-4dca-9914-e33d5eb7baf3

# Optimised Navigation Stack

This PR also modifies the navigation stack behaviour on push to prevent pushing the same page that is already opened, and also modifies the existing stack to remove duplicate pages. This allows less pages to be on the stack, and less confusion when navigating.

### Before:

https://github.com/user-attachments/assets/47c013bc-b32d-412a-9b51-64b28e5be223

### After:

https://github.com/user-attachments/assets/dd3fbf8a-4014-4f34-bec7-c4971889424a