### PR TITLE
fix: massive UI memory leaks via PyGObject reference cycles in gesture handlers

### DIFF
--- a/src/player/lyrics_cache.py
+++ b/src/player/lyrics_cache.py
@@ -51,11 +51,25 @@ class LyricsCache:
     # Soft cap on cached files; oldest mtimes get evicted on insert.
     MAX_ENTRIES = 2000
 
+    # Cap on the in-memory mirror. The disk cache holds MAX_ENTRIES, but the
+    # `_mem` dict would otherwise grow once per *played* track for a whole
+    # session (each entry is a full lyrics payload, ~5-50KB) and never shrink.
+    MAX_MEM_ENTRIES = 64
+
     def __init__(self):
         self._lock = threading.Lock()
         # Per-process in-memory mirror so the lyrics view's repeated reads
-        # don't hit disk on every progression tick.
+        # don't hit disk on every progression tick. Bounded LRU-ish: oldest
+        # insertion is dropped past MAX_MEM_ENTRIES (see _mem_put).
         self._mem = {}
+
+    def _mem_put(self, video_id, entry):
+        # Refresh recency: re-insert at the end so eviction drops genuinely
+        # stale entries, then trim from the front (oldest insertion).
+        self._mem.pop(video_id, None)
+        self._mem[video_id] = entry
+        while len(self._mem) > self.MAX_MEM_ENTRIES:
+            self._mem.pop(next(iter(self._mem)))
 
     def load(self, video_id):
         """Return the entire cache entry for ``video_id``, or ``None`` if
@@ -78,7 +92,7 @@ class LyricsCache:
             return None
         data.setdefault("results", {})
         data.setdefault("preferred_source", None)
-        self._mem[video_id] = data
+        self._mem_put(video_id, data)
         return data
 
     def get_result(self, video_id):
@@ -170,7 +184,7 @@ class LyricsCache:
                 with open(path, "w") as f:
                     json.dump(entry, f)
             os.utime(path, None)
-            self._mem[video_id] = entry
+            self._mem_put(video_id, entry)
             self._evict_old()
         except OSError as e:
             print(f"[LYRICS-CACHE] write failed for {video_id}: {e}")

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -32,6 +32,34 @@ else:
 from player.discord_rpc import DiscordRPCAdapter
 
 
+_libc = None
+_last_malloc_trim = 0.0
+
+
+def _malloc_trim(min_interval=0.0):
+    """Hand glibc's freed-but-retained heap back to the OS. After a track is
+    torn down, free() leaves the blocks sitting in the arena so RSS stays
+    high — this is the "memory isn't released after I clear the queue" the
+    user sees. With MALLOC_ARENA_MAX=2 (set in main.py) almost all allocation
+    lives in the main arena, which malloc_trim(0) can actually return. No-op
+    off glibc. `min_interval` throttles back-to-back calls (rapid skips)."""
+    global _libc, _last_malloc_trim
+    if not sys.platform.startswith("linux"):
+        return
+    import time as _t
+    now = _t.monotonic()
+    if min_interval and (now - _last_malloc_trim) < min_interval:
+        return
+    try:
+        import ctypes
+        if _libc is None:
+            _libc = ctypes.CDLL("libc.so.6")
+        _libc.malloc_trim(0)
+        _last_malloc_trim = now
+    except Exception:
+        pass
+
+
 def _extract_spectrum_bands(structure):
     """Pull a list[float] of magnitudes out of a GStreamer `spectrum`
     bus-message Structure. Returns None if no path yields data.
@@ -628,6 +656,10 @@ class Player(GObject.Object):
         self._current_source_video_id = None
         self.emit("state-changed", "stopped")
         self.emit("metadata-changed", "", "", "", "", "INDIFFERENT")
+        # The user explicitly dropped the whole queue — a good moment to
+        # return the freed decode/UI buffers to the OS rather than letting
+        # glibc sit on them.
+        _malloc_trim()
 
     def play_queue_index(self, index):
         import traceback as _tb
@@ -1039,6 +1071,10 @@ class Player(GObject.Object):
         # control of the pipeline. Don't let a late stream-start apply
         # the obsolete index.
         self._pending_gapless_index = None
+        # Each track change frees the previous stream's decode buffers; nudge
+        # glibc to return them to the OS so RSS doesn't ratchet up over a long
+        # session. Throttled so rapid skipping doesn't thrash the heap walk.
+        _malloc_trim(min_interval=10.0)
         # set_state(NULL) blocks until the pipeline flushes buffers and
         # closes any open HTTP sockets — measured at ~800ms occasionally
         # when the previous track was streaming. Running it on the main

--- a/src/ui/expanded_player.py
+++ b/src/ui/expanded_player.py
@@ -1,4 +1,5 @@
 import threading
+import weakref
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gdk, Gio
 from ui.utils import AsyncPicture, LikeButton, MarqueeLabel, show_toast
 from ui.queue_panel import QueuePanel
@@ -714,13 +715,15 @@ class ExpandedPlayer(Gtk.Box):
         from ui.widgets.add_to_playlist import mark_playlist_used
         mark_playlist_used(target_pid)
 
+        weak_self = weakref.ref(self)
+        client = self.player.client
         def _thread():
             # add_playlist_items auto-swaps OMV→ATV for single-item
             # adds, so even if the player's own swap hasn't run yet,
             # the audio version still ends up in the playlist.
-            success = self.player.client.add_playlist_items(target_pid, [vid])
+            success = client.add_playlist_items(target_pid, [vid])
             msg = "Added to playlist" if success else "Failed to add"
-            GLib.idle_add(self._show_toast, msg)
+            GLib.idle_add(lambda: weak_self()._show_toast(msg) if weak_self() else None)
 
         threading.Thread(target=_thread, daemon=True).start()
 

--- a/src/ui/pages/album.py
+++ b/src/ui/pages/album.py
@@ -39,8 +39,16 @@ class AlbumPage(BasePlaylistPage):
         thread.start()
 
     def _fetch_details(self):
+        if getattr(self, "_cleaned_up", False):
+            return
+        client = self.client
+        pid = self.playlist_id
+        if not client or not pid:
+            return
         try:
-            data = self.client.get_album(self.playlist_id)
+            data = client.get_album(pid)
+            if getattr(self, "_cleaned_up", False):
+                return
             title = data.get("title", "Unknown Album")
             description = data.get("description", "")
             tracks = data.get("tracks", [])
@@ -88,6 +96,8 @@ class AlbumPage(BasePlaylistPage):
                     if not t.get("thumbnails"):
                         t["thumbnails"] = thumbnails
 
+            if getattr(self, "_cleaned_up", False):
+                return
             GObject.idle_add(
                 self.update_ui, title, description, meta1, meta2, thumbnails, tracks
             )
@@ -111,3 +121,6 @@ class AlbumPage(BasePlaylistPage):
             title, description, meta1, meta2, thumbnails, tracks, append, total_tracks
         )
         # self.sort_row.set_visible(False)
+
+    def cleanup(self):
+        super().cleanup()

--- a/src/ui/pages/album.py
+++ b/src/ui/pages/album.py
@@ -39,16 +39,12 @@ class AlbumPage(BasePlaylistPage):
         thread.start()
 
     def _fetch_details(self):
-        if getattr(self, "_cleaned_up", False):
-            return
         client = self.client
         pid = self.playlist_id
         if not client or not pid:
             return
         try:
             data = client.get_album(pid)
-            if getattr(self, "_cleaned_up", False):
-                return
             title = data.get("title", "Unknown Album")
             description = data.get("description", "")
             tracks = data.get("tracks", [])
@@ -96,8 +92,6 @@ class AlbumPage(BasePlaylistPage):
                     if not t.get("thumbnails"):
                         t["thumbnails"] = thumbnails
 
-            if getattr(self, "_cleaned_up", False):
-                return
             GObject.idle_add(
                 self.update_ui, title, description, meta1, meta2, thumbnails, tracks
             )
@@ -122,5 +116,3 @@ class AlbumPage(BasePlaylistPage):
         )
         # self.sort_row.set_visible(False)
 
-    def cleanup(self):
-        super().cleanup()

--- a/src/ui/pages/all_moods.py
+++ b/src/ui/pages/all_moods.py
@@ -10,7 +10,6 @@ class AllMoodsPage(Adw.Bin):
     def __init__(self, items, title, *args, **kwargs):
         super().__init__(*args, **kwargs)
         weak_self = weakref.ref(self)
-        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.items = items
         self.category_title = title
 
@@ -106,32 +105,3 @@ class AllMoodsPage(Adw.Bin):
             if hasattr(root, "open_category"):
                 nav_title = item.get("title", self.category_title)
                 root.open_category(item["params"], nav_title)
-
-    def _on_page_destroy(self, widget):
-        self.cleanup()
-
-    def cleanup(self):
-        """Clean up resources to prevent memory leaks."""
-        self._cleaned_up = True
-        self.items = []
-        if hasattr(self, "list_box") and self.list_box:
-            child = self.list_box.get_first_child()
-            while child:
-                next_child = child.get_next_sibling()
-                try:
-                    self.list_box.remove(child)
-                except Exception:
-                    pass
-                child = next_child
-        if hasattr(self, "scrolled") and self.scrolled:
-            try:
-                self.scrolled.set_child(None)
-            except Exception:
-                pass
-
-        # Clear references to break reference cycles
-        self.list_box = None
-        self.scrolled = None
-        self.main_box = None
-        self.content_box = None
-        self.clamp = None

--- a/src/ui/pages/all_moods.py
+++ b/src/ui/pages/all_moods.py
@@ -1,3 +1,4 @@
+import weakref
 from gi.repository import Gtk, Adw, GObject
 from ui.util_classes import ScrolledWindow
 
@@ -8,6 +9,8 @@ class AllMoodsPage(Adw.Bin):
 
     def __init__(self, items, title, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        weak_self = weakref.ref(self)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.items = items
         self.category_title = title
 
@@ -61,9 +64,9 @@ class AllMoodsPage(Adw.Bin):
             row.set_child(box)
             row.item_data = item
             
-            click_gesture = Gtk.GestureClick()
-            click_gesture.set_button(1)
-            click_gesture.connect("released", self._on_row_activated, item)
+            click_gesture.connect(
+                "released", lambda g, n, x, y, it=item: weak_self()._on_row_activated(g, n, x, y, it) if weak_self() else None
+            )
             row.add_controller(click_gesture)
             
             self.list_box.append(row)
@@ -80,7 +83,7 @@ class AllMoodsPage(Adw.Bin):
 
         self.set_child(self.main_box)
         
-        self.connect("map", self._on_map)
+        self.connect("map", lambda w: weak_self()._on_map(w) if weak_self() else None)
 
     def filter_content(self, text):
         query = text.lower().strip()
@@ -103,3 +106,32 @@ class AllMoodsPage(Adw.Bin):
             if hasattr(root, "open_category"):
                 nav_title = item.get("title", self.category_title)
                 root.open_category(item["params"], nav_title)
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources to prevent memory leaks."""
+        self._cleaned_up = True
+        self.items = []
+        if hasattr(self, "list_box") and self.list_box:
+            child = self.list_box.get_first_child()
+            while child:
+                next_child = child.get_next_sibling()
+                try:
+                    self.list_box.remove(child)
+                except Exception:
+                    pass
+                child = next_child
+        if hasattr(self, "scrolled") and self.scrolled:
+            try:
+                self.scrolled.set_child(None)
+            except Exception:
+                pass
+
+        # Clear references to break reference cycles
+        self.list_box = None
+        self.scrolled = None
+        self.main_box = None
+        self.content_box = None
+        self.clamp = None

--- a/src/ui/pages/artist.py
+++ b/src/ui/pages/artist.py
@@ -895,10 +895,10 @@ class ArtistPage(Adw.Bin):
             click_gesture = Gtk.GestureClick()
             click_gesture.set_button(1)
             click_gesture.connect(
-                "pressed", lambda g, n, x, y, wib=weakref.ref(item_box): weak_self()._on_grid_item_pressed(g, n, x, y, wib()) if weak_self() and wib() else None
+                "pressed", lambda g, n, x, y: weak_self()._on_grid_item_pressed(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             click_gesture.connect(
-                "released", lambda g, n, x, y, wib=weakref.ref(item_box): weak_self()._on_grid_item_clicked(g, n, x, y, wib()) if weak_self() and wib() else None
+                "released", lambda g, n, x, y: weak_self()._on_grid_item_clicked(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(click_gesture)
 
@@ -906,14 +906,14 @@ class ArtistPage(Adw.Bin):
             gesture = Gtk.GestureClick()
             gesture.set_button(3)
             gesture.connect(
-                "released", lambda g, n, x, y, wib=weakref.ref(item_box): weak_self().on_grid_right_click(g, n, x, y, wib()) if weak_self() and wib() else None
+                "released", lambda g, n, x, y: weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, wib=weakref.ref(item_box): weak_self().on_grid_right_click(g, 1, x, y, wib()) if weak_self() and wib() else None
+                "pressed", lambda g, x, y: weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(lp)
 

--- a/src/ui/pages/artist.py
+++ b/src/ui/pages/artist.py
@@ -20,7 +20,6 @@ class ArtistPage(Adw.Bin):
         super().__init__(*args, **kwargs)
         self.player = player
         weak_self = weakref.ref(self)
-        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.artist_name = ""
@@ -279,8 +278,6 @@ class ArtistPage(Adw.Bin):
         thread.start()
 
     def _fetch_artist(self, channel_id):
-        if getattr(self, "_cleaned_up", False):
-            return
         client = self.client
         if not client:
             return
@@ -376,8 +373,6 @@ class ArtistPage(Adw.Bin):
 
             def detail_fetch(key, browse_id, params):
                 try:
-                    if getattr(self, "_cleaned_up", False):
-                        return
                     # Limit to 10 for the initial view as requested
                     detailed_items = client.get_artist_albums(
                         browse_id, params, limit=10
@@ -424,16 +419,12 @@ class ArtistPage(Adw.Bin):
             for t in detail_threads:
                 t.join(timeout=10.0)  # Generous timeout for multiple deep fetches
 
-            if getattr(self, "_cleaned_up", False):
-                return
             self._is_ui_init = False  # Fresh load
             GLib.idle_add(self.update_ui, self._artist_data)
         except Exception as e:
             print(f"Error fetching artist: {e}")
 
     def update_ui(self, data):
-        if getattr(self, "_cleaned_up", False):
-            return
         if not data:
             return
 
@@ -714,14 +705,14 @@ class ArtistPage(Adw.Bin):
             gesture = Gtk.GestureClick()
             gesture.set_button(3)
             gesture.connect(
-                "pressed", lambda g, n, x, y, : weak_self().on_song_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, n, x, y: weak_self().on_song_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             row.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, : weak_self().on_song_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, x, y: weak_self().on_song_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             row.add_controller(lp)
 
@@ -898,10 +889,7 @@ class ArtistPage(Adw.Bin):
 
             inner_box.append(item_box)
 
-            # Keep strong reference to prevent PyGObject from dropping the wrapper
-            if not hasattr(self, '_alive_grid_items'):
-                self._alive_grid_items = []
-            self._alive_grid_items.append(item_box)
+
 
             # Left Click Activation
             click_gesture = Gtk.GestureClick()
@@ -1464,53 +1452,3 @@ class ArtistPage(Adw.Bin):
         else:
             self.emit("header-title-changed", "")
 
-    def _on_page_destroy(self, widget):
-        self.cleanup()
-
-    def cleanup(self):
-        """Clean up resources to prevent memory leaks."""
-        self._cleaned_up = True
-
-        # Disconnect scroll handler
-        if getattr(self, "_scroll_handler_id", None) is not None:
-            if hasattr(self, "vadjust") and self.vadjust:
-                try:
-                    self.vadjust.disconnect(self._scroll_handler_id)
-                except Exception:
-                    pass
-            self._scroll_handler_id = None
-
-        # Disconnect banner fade handler from root window
-        if getattr(self, "_banner_fade_root_handler", None) and hasattr(self, "banner_wrapper"):
-            root = self.banner_wrapper.get_root()
-            if root:
-                try:
-                    root.disconnect(self._banner_fade_root_handler)
-                except Exception:
-                    pass
-            self._banner_fade_root_handler = None
-
-        # Recursively cleanup image widgets to cancel pending async loads
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        self.current_songs = []
-        self._artist_data = None
-        self._section_widgets = {}
-
-        if hasattr(self, "sections_box") and self.sections_box:
-            child = self.sections_box.get_first_child()
-            while child:
-                next_child = child.get_next_sibling()
-                try:
-                    self.sections_box.remove(child)
-                except Exception:
-                    pass
-                child = next_child
-
-        # Clear references to break reference cycles
-        self.player = None
-        self.client = None
-        self.main_box = None
-        self.vadjust = None
-        self.clamp = None

--- a/src/ui/pages/artist.py
+++ b/src/ui/pages/artist.py
@@ -1,5 +1,6 @@
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gdk, Gio
 import threading
+import weakref
 import json
 import re
 from api.client import MusicClient
@@ -18,6 +19,8 @@ class ArtistPage(Adw.Bin):
     def __init__(self, player, open_playlist_callback, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
+        weak_self = weakref.ref(self)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.artist_name = ""
@@ -42,7 +45,9 @@ class ArtistPage(Adw.Bin):
         # Monitor scroll for title
         vadjust = scrolled.get_vadjustment()
         self.vadjust = vadjust
-        vadjust.connect("value-changed", self._on_scroll)
+        self._scroll_handler_id = vadjust.connect(
+            "value-changed", lambda adj: weak_self()._on_scroll(adj) if weak_self() else None
+        )
 
         # Main Clamp
         self.clamp = Adw.Clamp()
@@ -91,30 +96,37 @@ class ArtistPage(Adw.Bin):
         # opaque (would paint a solid band over the blur), so we mask
         # the image itself to alpha 0 instead. Re-check on every realize
         # plus on a notify::css-classes from the root window.
+        weak_self = weakref.ref(self)
         def _sync_banner_fade(*_):
-            root = self.banner_wrapper.get_root()
+            s = weak_self()
+            if not s:
+                return
+            root = s.banner_wrapper.get_root()
             classes = list(root.get_css_classes()) if root else []
             active = "cover-bg-active" in classes
             print(
                 f"[FADE-SYNC] root={type(root).__name__ if root else None}"
                 f" classes={classes} active={active}"
             )
-            self.banner_wrapper.set_fade_active(active)
+            s.banner_wrapper.set_fade_active(active)
 
         self._sync_banner_fade = _sync_banner_fade
         self._banner_fade_root_handler = None
 
         def _hook_root(*_):
-            root = self.banner_wrapper.get_root()
-            if root and self._banner_fade_root_handler is None:
-                self._banner_fade_root_handler = root.connect(
+            s = weak_self()
+            if not s:
+                return
+            root = s.banner_wrapper.get_root()
+            if root and s._banner_fade_root_handler is None:
+                s._banner_fade_root_handler = root.connect(
                     "notify::css-classes", _sync_banner_fade
                 )
             _sync_banner_fade()
 
-        self.banner_wrapper.connect("realize", _hook_root)
+        self.banner_wrapper.connect("realize", lambda *_: _hook_root())
         self.banner_wrapper.connect(
-            "map", lambda *_: GLib.idle_add(_hook_root)
+            "map", lambda *_: GLib.idle_add(lambda: _hook_root())
         )
 
         # Visual Scrim
@@ -167,7 +179,7 @@ class ArtistPage(Adw.Bin):
         self.play_btn = Gtk.Button(label="Play")
         self.play_btn.add_css_class("suggested-action")
         self.play_btn.add_css_class("pill")
-        self.play_btn.connect("clicked", self.on_play_clicked)
+        self.play_btn.connect("clicked", lambda btn: weak_self().on_play_clicked(btn) if weak_self() else None)
         actions.append(self.play_btn)
 
         self.shuffle_btn = Gtk.Button()
@@ -176,7 +188,7 @@ class ArtistPage(Adw.Bin):
         self.shuffle_btn.set_valign(Gtk.Align.CENTER)
         self.shuffle_btn.set_size_request(48, 48)
         self.shuffle_btn.set_tooltip_text("Shuffle")
-        self.shuffle_btn.connect("clicked", self.on_shuffle_clicked)
+        self.shuffle_btn.connect("clicked", lambda btn: weak_self().on_shuffle_clicked(btn) if weak_self() else None)
         actions.append(self.shuffle_btn)
 
         self.radio_btn = Gtk.Button()
@@ -185,7 +197,7 @@ class ArtistPage(Adw.Bin):
         self.radio_btn.set_valign(Gtk.Align.CENTER)
         self.radio_btn.set_size_request(48, 48)
         self.radio_btn.set_tooltip_text("Start Radio")
-        self.radio_btn.connect("clicked", self.on_radio_clicked)
+        self.radio_btn.connect("clicked", lambda btn: weak_self().on_radio_clicked(btn) if weak_self() else None)
         actions.append(self.radio_btn)
 
         self.subscribe_btn = Gtk.Button()
@@ -195,7 +207,7 @@ class ArtistPage(Adw.Bin):
         self.subscribe_btn.set_valign(Gtk.Align.CENTER)
         self.subscribe_btn.set_size_request(48, 48)
         self.subscribe_btn.set_tooltip_text("Subscribe")
-        self.subscribe_btn.connect("clicked", self.on_subscribe_clicked)
+        self.subscribe_btn.connect("clicked", lambda btn: weak_self().on_subscribe_clicked(btn) if weak_self() else None)
         actions.append(self.subscribe_btn)
 
         # Description
@@ -215,7 +227,9 @@ class ArtistPage(Adw.Bin):
         self.read_more_btn.add_css_class("caption")
         self.read_more_btn.set_halign(Gtk.Align.START)
         self.read_more_btn.set_visible(False)
-        self.read_more_btn.connect("activate-link", self._on_read_more_link)
+        self.read_more_btn.connect(
+            "activate-link", lambda label, uri: weak_self()._on_read_more_link(label, uri) if weak_self() else None
+        )
         self._description_expanded = False
 
         self.description_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
@@ -265,13 +279,18 @@ class ArtistPage(Adw.Bin):
         thread.start()
 
     def _fetch_artist(self, channel_id):
+        if getattr(self, "_cleaned_up", False):
+            return
+        client = self.client
+        if not client:
+            return
         try:
-            self._artist_data = self.client.get_artist(channel_id)
+            self._artist_data = client.get_artist(channel_id)
 
             # Fetch missing sections (playlists, featured on, live) from raw API
             if self._artist_data and not self._artist_data.get("_is_channel"):
                 try:
-                    raw = self.client.api._send_request(
+                    raw = client.api._send_request(
                         "browse", {"browseId": channel_id}
                     )
                     tabs = (
@@ -319,7 +338,7 @@ class ArtistPage(Adw.Bin):
                                 ):
                                     items = []
                                     for raw_item in r.get("contents", []):
-                                        parsed = self.client._parse_channel_item(
+                                        parsed = client._parse_channel_item(
                                             raw_item
                                         )
                                         if parsed:
@@ -337,7 +356,7 @@ class ArtistPage(Adw.Bin):
                                 ):
                                     items = []
                                     for raw_item in r.get("contents", []):
-                                        parsed = self.client._parse_channel_item(
+                                        parsed = client._parse_channel_item(
                                             raw_item
                                         )
                                         if parsed:
@@ -357,8 +376,10 @@ class ArtistPage(Adw.Bin):
 
             def detail_fetch(key, browse_id, params):
                 try:
+                    if getattr(self, "_cleaned_up", False):
+                        return
                     # Limit to 10 for the initial view as requested
-                    detailed_items = self.client.get_artist_albums(
+                    detailed_items = client.get_artist_albums(
                         browse_id, params, limit=10
                     )
                     if detailed_items:
@@ -377,7 +398,7 @@ class ArtistPage(Adw.Bin):
                     if b_id:
                         # For songs, we use get_playlist to get the full list
                         fetch_target = (
-                            self.client.get_playlist if key == "songs" else detail_fetch
+                            client.get_playlist if key == "songs" else detail_fetch
                         )
                         target_args = (
                             (b_id,) if key == "songs" else (key, b_id, p_params)
@@ -403,12 +424,16 @@ class ArtistPage(Adw.Bin):
             for t in detail_threads:
                 t.join(timeout=10.0)  # Generous timeout for multiple deep fetches
 
+            if getattr(self, "_cleaned_up", False):
+                return
             self._is_ui_init = False  # Fresh load
             GLib.idle_add(self.update_ui, self._artist_data)
         except Exception as e:
             print(f"Error fetching artist: {e}")
 
     def update_ui(self, data):
+        if getattr(self, "_cleaned_up", False):
+            return
         if not data:
             return
 
@@ -446,16 +471,17 @@ class ArtistPage(Adw.Bin):
 
         subs = data.get("subscribers") or ""
         if subs:
-            subs += " subscribers"
+            subs = str(subs) + " subscribers"
 
         views = data.get("views")
         if views:
+            views = str(views)
             if subs:
                 subs += " • " + views
             else:
                 subs = views
 
-        self.subscribers_label.set_label(subs)
+        self.subscribers_label.set_label(str(subs))
 
         # Subscription Status
         self._is_subscribed = data.get("subscribed", False)
@@ -562,7 +588,8 @@ class ArtistPage(Adw.Bin):
         list_box = Gtk.ListBox()
         list_box.add_css_class("boxed-list")
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
-        list_box.connect("row-activated", self.on_song_activated)
+        weak_self = weakref.ref(self)
+        list_box.connect("row-activated", lambda lb, r: weak_self().on_song_activated(lb, r) if weak_self() else None)
 
         limit = self._section_limits.get(title, 5)
         showing_items = items[:limit]
@@ -678,6 +705,7 @@ class ArtistPage(Adw.Bin):
                 )
                 like_btn.set_valign(Gtk.Align.CENTER)
                 box.append(like_btn)
+                row._like_btn = like_btn
 
             row.item_data = item
             list_box.append(row)
@@ -685,14 +713,15 @@ class ArtistPage(Adw.Bin):
             # Context Menu
             gesture = Gtk.GestureClick()
             gesture.set_button(3)
-            gesture.connect("pressed", self.on_song_right_click, row)
+            gesture.connect(
+                "pressed", lambda g, n, x, y, : weak_self().on_song_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            )
             row.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed",
-                lambda g, x, y, r=row: self.on_song_right_click(g, 1, x, y, r),
+                "pressed", lambda g, x, y, : weak_self().on_song_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             row.add_controller(lp)
 
@@ -718,7 +747,7 @@ class ArtistPage(Adw.Bin):
             load_more_btn.connect(
                 "clicked",
                 lambda btn, t=title, sd=section_dict, s=spinner, lmb=load_more_btn: (
-                    self.on_load_more_clicked(lmb, t, sd, s, lmb)
+                    weak_self().on_load_more_clicked(lmb, t, sd, s, lmb) if weak_self() else None
                 ),
             )
             section_box.append(btn_box)
@@ -765,6 +794,7 @@ class ArtistPage(Adw.Bin):
             self.subscribe_btn.remove_css_class("liked-button")
 
     def add_grid_section(self, title, section_dict):
+        weak_self = weakref.ref(self)
         items = section_dict.get("results", [])
         if not items:
             return
@@ -868,24 +898,34 @@ class ArtistPage(Adw.Bin):
 
             inner_box.append(item_box)
 
+            # Keep strong reference to prevent PyGObject from dropping the wrapper
+            if not hasattr(self, '_alive_grid_items'):
+                self._alive_grid_items = []
+            self._alive_grid_items.append(item_box)
+
             # Left Click Activation
             click_gesture = Gtk.GestureClick()
             click_gesture.set_button(1)
-            click_gesture.connect("pressed", self._on_grid_item_pressed, item_box)
-            click_gesture.connect("released", self._on_grid_item_clicked, item_box)
+            click_gesture.connect(
+                "pressed", lambda g, n, x, y, wib=weakref.ref(item_box): weak_self()._on_grid_item_pressed(g, n, x, y, wib()) if weak_self() and wib() else None
+            )
+            click_gesture.connect(
+                "released", lambda g, n, x, y, wib=weakref.ref(item_box): weak_self()._on_grid_item_clicked(g, n, x, y, wib()) if weak_self() and wib() else None
+            )
             item_box.add_controller(click_gesture)
 
             # Right Click Menu
             gesture = Gtk.GestureClick()
             gesture.set_button(3)
-            gesture.connect("released", self.on_grid_right_click, item_box)
+            gesture.connect(
+                "released", lambda g, n, x, y, wib=weakref.ref(item_box): weak_self().on_grid_right_click(g, n, x, y, wib()) if weak_self() and wib() else None
+            )
             item_box.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed",
-                lambda g, x, y, ib=item_box: self.on_grid_right_click(g, 1, x, y, ib),
+                "pressed", lambda g, x, y, wib=weakref.ref(item_box): weak_self().on_grid_right_click(g, 1, x, y, wib()) if weak_self() and wib() else None
             )
             item_box.add_controller(lp)
 
@@ -906,8 +946,8 @@ class ArtistPage(Adw.Bin):
             # Click handler for Load More using the button directly
             more_btn.connect(
                 "clicked",
-                lambda btn, t=title, sd=section_dict: self.on_load_more_clicked(
-                    btn, t, sd, None, btn
+                lambda btn, t=title, sd=section_dict: (
+                    weak_self().on_load_more_clicked(btn, t, sd, None, btn) if weak_self() else None
                 ),
             )
 
@@ -1042,7 +1082,9 @@ class ArtistPage(Adw.Bin):
 
         threading.Thread(target=thread_func, daemon=True).start()
 
-    def on_grid_right_click(self, gesture, n_press, x, y, item_box):
+    def on_grid_right_click(self, gesture, n_press, x, y, item_box=None):
+        if item_box is None:
+            item_box = gesture.get_widget()
         if not hasattr(item_box, "item_data"):
             return
         data = item_box.item_data
@@ -1273,6 +1315,7 @@ class ArtistPage(Adw.Bin):
                     },
                 )
 
+
     def _build_queue_tracks(self):
         queue_tracks = []
         # Use full results from _artist_data to ensure all songs are added to queue
@@ -1420,3 +1463,54 @@ class ArtistPage(Adw.Bin):
             self.emit("header-title-changed", self.artist_name)
         else:
             self.emit("header-title-changed", "")
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources to prevent memory leaks."""
+        self._cleaned_up = True
+
+        # Disconnect scroll handler
+        if getattr(self, "_scroll_handler_id", None) is not None:
+            if hasattr(self, "vadjust") and self.vadjust:
+                try:
+                    self.vadjust.disconnect(self._scroll_handler_id)
+                except Exception:
+                    pass
+            self._scroll_handler_id = None
+
+        # Disconnect banner fade handler from root window
+        if getattr(self, "_banner_fade_root_handler", None) and hasattr(self, "banner_wrapper"):
+            root = self.banner_wrapper.get_root()
+            if root:
+                try:
+                    root.disconnect(self._banner_fade_root_handler)
+                except Exception:
+                    pass
+            self._banner_fade_root_handler = None
+
+        # Recursively cleanup image widgets to cancel pending async loads
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        self.current_songs = []
+        self._artist_data = None
+        self._section_widgets = {}
+
+        if hasattr(self, "sections_box") and self.sections_box:
+            child = self.sections_box.get_first_child()
+            while child:
+                next_child = child.get_next_sibling()
+                try:
+                    self.sections_box.remove(child)
+                except Exception:
+                    pass
+                child = next_child
+
+        # Clear references to break reference cycles
+        self.player = None
+        self.client = None
+        self.main_box = None
+        self.vadjust = None
+        self.clamp = None

--- a/src/ui/pages/base_playlist.py
+++ b/src/ui/pages/base_playlist.py
@@ -135,6 +135,9 @@ class BasePlaylistPage(Adw.Bin):
         actions_box.set_margin_top(12)
         self.actions_box = actions_box
 
+        play_btn = Gtk.Button(label="Play")
+        play_btn.add_css_class("suggested-action")
+        play_btn.add_css_class("pill")
         play_btn.connect("clicked", lambda btn: weak_self().on_play_clicked(btn) if weak_self() else None)
         actions_box.append(play_btn)
 
@@ -215,7 +218,9 @@ class BasePlaylistPage(Adw.Bin):
         # ListView Setup
         self.store = Gio.ListStore(item_type=SongItem)
         self.filter_model = Gtk.FilterListModel(model=self.store)
-        self.custom_filter = Gtk.CustomFilter.new(self._filter_func)
+        self.custom_filter = Gtk.CustomFilter.new(
+            lambda item: weak_self()._filter_func(item) if weak_self() else False
+        )
         self.filter_model.set_filter(self.custom_filter)
 
         self.sort_model = Gtk.SortListModel(model=self.filter_model)
@@ -305,19 +310,8 @@ class BasePlaylistPage(Adw.Bin):
         self.cleanup()
 
     def cleanup(self):
-        """Perform resource cleanup when the page is popped/destroyed."""
+        """Disconnect long-lived signal handlers that prevent GC."""
         self._cleaned_up = True
-
-        # Disconnect scroll handler
-        if getattr(self, "_scroll_handler_id", None) is not None:
-            if hasattr(self, "vadjust") and self.vadjust:
-                try:
-                    self.vadjust.disconnect(self._scroll_handler_id)
-                except Exception:
-                    pass
-            self._scroll_handler_id = None
-
-        # Disconnect player signals
         hid = getattr(self, "_player_metadata_handler", None)
         if hid is not None:
             try:
@@ -325,25 +319,6 @@ class BasePlaylistPage(Adw.Bin):
             except Exception:
                 pass
             self._player_metadata_handler = None
-
-        # Clear store and tracks to break references
-        if hasattr(self, "store") and self.store:
-            try:
-                self.store.remove_all()
-            except Exception:
-                pass
-        self.current_tracks = []
-        self.original_tracks = []
-
-        # Recursively cleanup image widgets to cancel pending async loads
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        # Clear references to break GObject reference cycles
-        self.player = None
-        self.client = None
-        self.main_box = None
-        self.vadjust = None
 
     def _on_factory_setup(self, factory, list_item):
         widget = SongRowWidget(self.player, self.client)
@@ -489,8 +464,7 @@ class BasePlaylistPage(Adw.Bin):
         append=False,
         total_tracks=None,
     ):
-        if getattr(self, "_cleaned_up", False):
-            return
+
         self.stack.set_visible_child_name("content")
         self.content_spinner.set_visible(False)
         self.playlist_title_text = title

--- a/src/ui/pages/base_playlist.py
+++ b/src/ui/pages/base_playlist.py
@@ -1,5 +1,6 @@
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gdk, Gio
 import threading
+import weakref
 import re
 from api.client import MusicClient
 from ui.utils import AsyncImage, LikeButton, get_yt_music_link, show_toast
@@ -16,8 +17,9 @@ class BasePlaylistPage(Adw.Bin):
     def __init__(self, player, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
-        self.connect("map", self._on_map)
-        self.connect("unmap", self._on_unmap)
+        weak_self = weakref.ref(self)
+        self.connect("map", lambda w: weak_self()._on_map(w) if weak_self() else None)
+        self.connect("unmap", lambda w: weak_self()._on_unmap(w) if weak_self() else None)
         self.client = MusicClient()
         self.playlist_id = None
         self.playlist_title_text = ""
@@ -33,7 +35,9 @@ class BasePlaylistPage(Adw.Bin):
         # Monitor scroll for title
         vadjust = scrolled.get_vadjustment()
         self.vadjust = vadjust
-        vadjust.connect("value-changed", self._on_scroll)
+        self._scroll_handler_id = vadjust.connect(
+            "value-changed", lambda adj: weak_self()._on_scroll(adj) if weak_self() else None
+        )
 
         # Clamp for content
         clamp = Adw.Clamp()
@@ -101,7 +105,9 @@ class BasePlaylistPage(Adw.Bin):
         self.read_more_btn.add_css_class("caption")
         self.read_more_btn.set_halign(Gtk.Align.START)
         self.read_more_btn.set_visible(False)
-        self.read_more_btn.connect("activate-link", self._on_read_more_clicked)
+        self.read_more_btn.connect(
+            "activate-link", lambda label, uri: weak_self()._on_read_more_clicked(label, uri) if weak_self() else None
+        )
 
         self.desc_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         self.desc_box.append(self.description_label)
@@ -114,7 +120,9 @@ class BasePlaylistPage(Adw.Bin):
         self.meta_label.set_wrap(True)
         self.meta_label.set_halign(Gtk.Align.START)
         self.meta_label.set_use_markup(True)
-        self.meta_label.connect("activate-link", self.on_meta_link_activated)
+        self.meta_label.connect(
+            "activate-link", lambda label, uri: weak_self().on_meta_link_activated(label, uri) if weak_self() else None
+        )
         self.details_col.append(self.meta_label)
 
         self.stats_label = Gtk.Label(label="")
@@ -127,17 +135,14 @@ class BasePlaylistPage(Adw.Bin):
         actions_box.set_margin_top(12)
         self.actions_box = actions_box
 
-        play_btn = Gtk.Button(label="Play")
-        play_btn.add_css_class("suggested-action")
-        play_btn.add_css_class("pill")
-        play_btn.connect("clicked", self.on_play_clicked)
+        play_btn.connect("clicked", lambda btn: weak_self().on_play_clicked(btn) if weak_self() else None)
         actions_box.append(play_btn)
 
         shuffle_btn = Gtk.Button()
         shuffle_btn.set_icon_name("media-playlist-shuffle-symbolic")
         shuffle_btn.add_css_class("circular")
         shuffle_btn.set_size_request(48, 48)
-        shuffle_btn.connect("clicked", self.on_shuffle_clicked)
+        shuffle_btn.connect("clicked", lambda btn: weak_self().on_shuffle_clicked(btn) if weak_self() else None)
         actions_box.append(shuffle_btn)
 
         # Simplified Actions (Play/Shuffle only)
@@ -161,15 +166,21 @@ class BasePlaylistPage(Adw.Bin):
         action_add = Gio.SimpleAction.new(
             "add_all_to_playlist", GLib.VariantType.new("s")
         )
-        action_add.connect("activate", self._on_add_all_to_playlist)
+        action_add.connect(
+            "activate", lambda a, p: weak_self()._on_add_all_to_playlist(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_add)
 
         action_show_add = Gio.SimpleAction.new("show_add_all_to_playlist", None)
-        action_show_add.connect("activate", self._on_show_add_all_to_playlist)
+        action_show_add.connect(
+            "activate", lambda a, p: weak_self()._on_show_add_all_to_playlist(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_show_add)
 
         action_copy = Gio.SimpleAction.new("copy_link", None)
-        action_copy.connect("activate", self.on_copy_link_clicked)
+        action_copy.connect(
+            "activate", lambda a, p: weak_self().on_copy_link_clicked(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_copy)
 
         self.sort_dropdown = Gtk.DropDown.new_from_strings(
@@ -185,7 +196,9 @@ class BasePlaylistPage(Adw.Bin):
         self.sort_dropdown.set_valign(Gtk.Align.CENTER)
         self.sort_dropdown.add_css_class("pill")
         self.sort_dropdown.add_css_class("sort-dropdown")
-        self.sort_dropdown.connect("notify::selected", self.on_sort_changed)
+        self.sort_dropdown.connect(
+            "notify::selected", lambda dd, spec: weak_self().on_sort_changed(dd, spec) if weak_self() else None
+        )
 
         self.details_col.append(actions_box)
         content_box.append(header_clamp)
@@ -212,16 +225,24 @@ class BasePlaylistPage(Adw.Bin):
         self.selection_model.set_autoselect(False)
 
         factory = Gtk.SignalListItemFactory()
-        factory.connect("setup", self._on_factory_setup)
-        factory.connect("bind", self._on_factory_bind)
-        factory.connect("unbind", self._on_factory_unbind)
+        factory.connect(
+            "setup", lambda f, li: weak_self()._on_factory_setup(f, li) if weak_self() else None
+        )
+        factory.connect(
+            "bind", lambda f, li: weak_self()._on_factory_bind(f, li) if weak_self() else None
+        )
+        factory.connect(
+            "unbind", lambda f, li: weak_self()._on_factory_unbind(f, li) if weak_self() else None
+        )
 
         self.songs_view = Gtk.ListView(model=self.selection_model, factory=factory)
         self.songs_view.add_css_class("boxed-list")
         # Keyboard activation: Enter/Space on the focused row plays it. The
         # ListView's "activate" signal passes an int position, which
         # on_song_activated already handles (alongside the click-gesture path).
-        self.songs_view.connect("activate", self.on_song_activated)
+        self.songs_view.connect(
+            "activate", lambda lv, pos: weak_self().on_song_activated(lv, pos) if weak_self() else None
+        )
         self.songs_view.set_visible(False)
         track_section.append(self.songs_view)
 
@@ -276,11 +297,27 @@ class BasePlaylistPage(Adw.Bin):
         # widget tree, track lists, etc.) leaks every time the user opens a
         # playlist. After heavy navigation that pinned hundreds of MB.
         self._player_metadata_handler = self.player.connect(
-            "metadata-changed", self._update_playing_indicator
+            "metadata-changed", lambda player, *args: weak_self()._update_playing_indicator(player, *args) if weak_self() else None
         )
-        self.connect("destroy", self._on_page_destroy)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
 
     def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Perform resource cleanup when the page is popped/destroyed."""
+        self._cleaned_up = True
+
+        # Disconnect scroll handler
+        if getattr(self, "_scroll_handler_id", None) is not None:
+            if hasattr(self, "vadjust") and self.vadjust:
+                try:
+                    self.vadjust.disconnect(self._scroll_handler_id)
+                except Exception:
+                    pass
+            self._scroll_handler_id = None
+
+        # Disconnect player signals
         hid = getattr(self, "_player_metadata_handler", None)
         if hid is not None:
             try:
@@ -288,6 +325,25 @@ class BasePlaylistPage(Adw.Bin):
             except Exception:
                 pass
             self._player_metadata_handler = None
+
+        # Clear store and tracks to break references
+        if hasattr(self, "store") and self.store:
+            try:
+                self.store.remove_all()
+            except Exception:
+                pass
+        self.current_tracks = []
+        self.original_tracks = []
+
+        # Recursively cleanup image widgets to cancel pending async loads
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        # Clear references to break GObject reference cycles
+        self.player = None
+        self.client = None
+        self.main_box = None
+        self.vadjust = None
 
     def _on_factory_setup(self, factory, list_item):
         widget = SongRowWidget(self.player, self.client)
@@ -433,6 +489,8 @@ class BasePlaylistPage(Adw.Bin):
         append=False,
         total_tracks=None,
     ):
+        if getattr(self, "_cleaned_up", False):
+            return
         self.stack.set_visible_child_name("content")
         self.content_spinner.set_visible(False)
         self.playlist_title_text = title

--- a/src/ui/pages/base_playlist.py
+++ b/src/ui/pages/base_playlist.py
@@ -436,14 +436,16 @@ class BasePlaylistPage(Adw.Bin):
         from ui.widgets.add_to_playlist import mark_playlist_used
         mark_playlist_used(playlist_id)
 
+        weak_self = weakref.ref(self)
+        client = self.client
         def thread_func():
-            success = self.client.add_playlist_items(playlist_id, video_ids)
+            success = client.add_playlist_items(playlist_id, video_ids)
             if success:
                 msg = f"Added {len(video_ids)} tracks to playlist"
                 print(msg)
-                GLib.idle_add(self._show_toast, msg)
+                GLib.idle_add(lambda: weak_self()._show_toast(msg) if weak_self() else None)
             else:
-                GLib.idle_add(self._show_toast, "Failed to add tracks")
+                GLib.idle_add(lambda: weak_self()._show_toast("Failed to add tracks") if weak_self() else None)
 
         threading.Thread(target=thread_func, daemon=True).start()
 

--- a/src/ui/pages/category.py
+++ b/src/ui/pages/category.py
@@ -15,8 +15,7 @@ class CategoryPage(Adw.Bin):
     def __init__(self, player, open_playlist_callback, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
-        weak_self = weakref.ref(self)
-        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
+
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.params = None
@@ -110,8 +109,6 @@ class CategoryPage(Adw.Bin):
         self._load_data()
 
     def _load_data(self):
-        if getattr(self, "_cleaned_up", False):
-            return
         if self._is_loading:
             return
 
@@ -125,26 +122,21 @@ class CategoryPage(Adw.Bin):
         client = self.client
         p = self.params
         def fetch_func():
-            if getattr(self, "_cleaned_up", False):
-                return
+
             try:
                 sections = client.get_category_page(p)
-                if getattr(self, "_cleaned_up", False):
-                    return
+
                 self._cached_sections = sections
                 self._cached_params = p
                 GLib.idle_add(self._render_sections, sections)
             except Exception as e:
                 print(f"Error loading category page: {e}")
-                if not getattr(self, "_cleaned_up", False):
-                    GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
-                    self._is_loading = False
+                GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
+                self._is_loading = False
 
         threading.Thread(target=fetch_func, daemon=True).start()
 
     def _render_sections(self, sections):
-        if getattr(self, "_cleaned_up", False):
-            return
         # Clear existing items again just in case
         child = self.content_box.get_first_child()
         while child:
@@ -265,13 +257,13 @@ class CategoryPage(Adw.Bin):
             right_click = Gtk.GestureClick()
             right_click.set_button(3)
             right_click.connect(
-                "released", lambda g, n, x, y, : weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "released", lambda g, n, x, y: weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(right_click)
 
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, : weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, x, y: weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(lp)
 
@@ -392,7 +384,7 @@ class CategoryPage(Adw.Bin):
             right_click = Gtk.GestureClick()
             right_click.set_button(3)
             right_click.connect(
-                "released", lambda g, n, x, y, : weak_self().on_song_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "released", lambda g, n, x, y: weak_self().on_song_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             row.add_controller(right_click)
 
@@ -584,38 +576,3 @@ class CategoryPage(Adw.Bin):
         elif browse_id:
             self.open_playlist_callback(browse_id)
 
-    def _on_page_destroy(self, widget):
-        self.cleanup()
-
-    def cleanup(self):
-        """Clean up resources to prevent memory leaks."""
-        self._cleaned_up = True
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        self._cached_sections = None
-        self._cached_params = None
-
-        if hasattr(self, "content_box") and self.content_box:
-            child = self.content_box.get_first_child()
-            while child:
-                next_child = child.get_next_sibling()
-                try:
-                    self.content_box.remove(child)
-                except Exception:
-                    pass
-                child = next_child
-
-        if hasattr(self, "scrolled") and self.scrolled:
-            try:
-                self.scrolled.set_child(None)
-            except Exception:
-                pass
-
-        # Clear references to break reference cycles
-        self.player = None
-        self.client = None
-        self.main_box = None
-        self.scrolled = None
-        self.content_box = None
-        self.clamp = None

--- a/src/ui/pages/category.py
+++ b/src/ui/pages/category.py
@@ -1,4 +1,5 @@
 import json
+import weakref
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gio, Gdk
 import threading
 from api.client import MusicClient
@@ -14,6 +15,8 @@ class CategoryPage(Adw.Bin):
     def __init__(self, player, open_playlist_callback, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
+        weak_self = weakref.ref(self)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.params = None
@@ -107,6 +110,8 @@ class CategoryPage(Adw.Bin):
         self._load_data()
 
     def _load_data(self):
+        if getattr(self, "_cleaned_up", False):
+            return
         if self._is_loading:
             return
 
@@ -117,20 +122,29 @@ class CategoryPage(Adw.Bin):
             GLib.idle_add(self._render_sections, self._cached_sections)
             return
 
+        client = self.client
+        p = self.params
         def fetch_func():
+            if getattr(self, "_cleaned_up", False):
+                return
             try:
-                sections = self.client.get_category_page(self.params)
+                sections = client.get_category_page(p)
+                if getattr(self, "_cleaned_up", False):
+                    return
                 self._cached_sections = sections
-                self._cached_params = self.params
+                self._cached_params = p
                 GLib.idle_add(self._render_sections, sections)
             except Exception as e:
                 print(f"Error loading category page: {e}")
-                GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
-                self._is_loading = False
+                if not getattr(self, "_cleaned_up", False):
+                    GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
+                    self._is_loading = False
 
         threading.Thread(target=fetch_func, daemon=True).start()
 
     def _render_sections(self, sections):
+        if getattr(self, "_cleaned_up", False):
+            return
         # Clear existing items again just in case
         child = self.content_box.get_first_child()
         while child:
@@ -241,17 +255,24 @@ class CategoryPage(Adw.Bin):
 
             click_gesture = Gtk.GestureClick()
             click_gesture.set_button(1)
-            click_gesture.connect("released", self._on_item_clicked, item)
+            weak_self = weakref.ref(self)
+            click_gesture.connect(
+                "released", lambda g, n, x, y, it=item: weak_self()._on_item_clicked(g, n, x, y, it) if weak_self() else None
+            )
             item_box.add_controller(click_gesture)
 
             # Right Click context menu
             right_click = Gtk.GestureClick()
             right_click.set_button(3)
-            right_click.connect("released", self.on_grid_right_click, item_box)
+            right_click.connect(
+                "released", lambda g, n, x, y, : weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            )
             item_box.add_controller(right_click)
 
             lp = Gtk.GestureLongPress()
-            lp.connect("pressed", lambda g, x, y, ib=item_box: self.on_grid_right_click(g, 1, x, y, ib))
+            lp.connect(
+                "pressed", lambda g, x, y, : weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            )
             item_box.add_controller(lp)
 
         scroll_box.set_content(inner_box)
@@ -353,6 +374,7 @@ class CategoryPage(Adw.Bin):
                 )
                 like_btn.set_valign(Gtk.Align.CENTER)
                 box.append(like_btn)
+                row._like_btn = like_btn
 
             row.item_data = item
             list_box.append(row)
@@ -360,13 +382,18 @@ class CategoryPage(Adw.Bin):
             # Left Click Activation
             click_gesture = Gtk.GestureClick()
             click_gesture.set_button(1)
-            click_gesture.connect("released", self._on_item_clicked, item)
+            weak_self = weakref.ref(self)
+            click_gesture.connect(
+                "released", lambda g, n, x, y, it=item: weak_self()._on_item_clicked(g, n, x, y, it) if weak_self() else None
+            )
             row.add_controller(click_gesture)
 
             # Right Click context menu
             right_click = Gtk.GestureClick()
             right_click.set_button(3)
-            right_click.connect("released", self.on_song_right_click, row)
+            right_click.connect(
+                "released", lambda g, n, x, y, : weak_self().on_song_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            )
             row.add_controller(right_click)
 
         section_box.append(list_box)
@@ -381,7 +408,9 @@ class CategoryPage(Adw.Bin):
             btn_box.set_halign(Gtk.Align.CENTER)
             btn_box.append(show_all_btn)
 
-            show_all_btn.connect("clicked", lambda btn, t=title: self.on_show_all_songs_clicked(t))
+            show_all_btn.connect(
+                "clicked", lambda btn, t=title: weak_self().on_show_all_songs_clicked(t) if weak_self() else None
+            )
             section_box.append(btn_box)
 
     def on_show_all_songs_clicked(self, title):
@@ -554,3 +583,39 @@ class CategoryPage(Adw.Bin):
             self.player.play_tracks([item])
         elif browse_id:
             self.open_playlist_callback(browse_id)
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources to prevent memory leaks."""
+        self._cleaned_up = True
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        self._cached_sections = None
+        self._cached_params = None
+
+        if hasattr(self, "content_box") and self.content_box:
+            child = self.content_box.get_first_child()
+            while child:
+                next_child = child.get_next_sibling()
+                try:
+                    self.content_box.remove(child)
+                except Exception:
+                    pass
+                child = next_child
+
+        if hasattr(self, "scrolled") and self.scrolled:
+            try:
+                self.scrolled.set_child(None)
+            except Exception:
+                pass
+
+        # Clear references to break reference cycles
+        self.player = None
+        self.client = None
+        self.main_box = None
+        self.scrolled = None
+        self.content_box = None
+        self.clamp = None

--- a/src/ui/pages/discography.py
+++ b/src/ui/pages/discography.py
@@ -16,7 +16,6 @@ class DiscographyPage(Adw.Bin):
         super().__init__(*args, **kwargs)
         self.player = player
         weak_self = weakref.ref(self)
-        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.channel_id = None
@@ -159,8 +158,6 @@ class DiscographyPage(Adw.Bin):
             self._load_more()
 
     def _load_more(self):
-        if getattr(self, "_cleaned_up", False):
-            return
         if self._is_loading or not self._has_more:
             return
 
@@ -172,8 +169,6 @@ class DiscographyPage(Adw.Bin):
         p = self.params
         t_title = self.title
         def fetch_func():
-            if getattr(self, "_cleaned_up", False):
-                return
             try:
                 new_items = []
                 if bid and "Top Songs" in t_title:
@@ -196,8 +191,6 @@ class DiscographyPage(Adw.Bin):
                     self._has_more = False
 
                 def update_cb():
-                    if getattr(self, "_cleaned_up", False):
-                        return
                     if new_items:
                         # Filter out items we already have
                         existing_ids = set()
@@ -224,14 +217,11 @@ class DiscographyPage(Adw.Bin):
                     if not new_items:
                         self._has_more = False
 
-                if getattr(self, "_cleaned_up", False):
-                    return
                 GLib.idle_add(update_cb)
             except Exception as e:
                 print(f"Error loading discography: {e}")
-                if not getattr(self, "_cleaned_up", False):
-                    GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
-                    self._is_loading = False
+                GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
+                self._is_loading = False
 
         threading.Thread(target=fetch_func, daemon=True).start()
 
@@ -306,14 +296,14 @@ class DiscographyPage(Adw.Bin):
             gesture.set_button(3)
             weak_self = weakref.ref(self)
             gesture.connect(
-                "pressed", lambda g, n, x, y, : weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, n, x, y: weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, : weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, x, y: weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(lp)
 
@@ -433,50 +423,3 @@ class DiscographyPage(Adw.Bin):
                 GLib.idle_add(window.player.extend_queue, tracks)
 
         threading.Thread(target=thread_func, daemon=True).start()
-
-    def _on_page_destroy(self, widget):
-        self.cleanup()
-
-    def cleanup(self):
-        """Clean up resources to prevent memory leaks."""
-        self._cleaned_up = True
-
-        # Disconnect scroll handler
-        if getattr(self, "_scroll_handler_id", None) is not None:
-            if hasattr(self, "scrolled") and self.scrolled:
-                try:
-                    vadjust = self.scrolled.get_vadjustment()
-                    if vadjust:
-                        vadjust.disconnect(self._scroll_handler_id)
-                except Exception:
-                    pass
-            self._scroll_handler_id = None
-
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        self.items = []
-
-        if hasattr(self, "flow_box") and self.flow_box:
-            child = self.flow_box.get_first_child()
-            while child:
-                next_child = child.get_next_sibling()
-                try:
-                    self.flow_box.remove(child)
-                except Exception:
-                    pass
-                child = next_child
-
-        if hasattr(self, "scrolled") and self.scrolled:
-            try:
-                self.scrolled.set_child(None)
-            except Exception:
-                pass
-
-        # Clear references to break reference cycles
-        self.player = None
-        self.client = None
-        self.main_box = None
-        self.scrolled = None
-        self.flow_box = None
-        self.content_box = None

--- a/src/ui/pages/discography.py
+++ b/src/ui/pages/discography.py
@@ -1,5 +1,6 @@
 from gi.repository import Gtk, Adw, GObject, GLib, Gio, Pango, Gdk
 import threading
+import weakref
 import json
 from api.client import MusicClient
 from ui.utils import AsyncImage, parse_item_metadata
@@ -14,6 +15,8 @@ class DiscographyPage(Adw.Bin):
     def __init__(self, player, open_playlist_callback, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
+        weak_self = weakref.ref(self)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.channel_id = None
@@ -36,7 +39,10 @@ class DiscographyPage(Adw.Bin):
         self.scrolled.set_vexpand(True)
 
         vadjust = self.scrolled.get_vadjustment()
-        vadjust.connect("value-changed", self._on_scroll)
+        weak_self = weakref.ref(self)
+        self._scroll_handler_id = vadjust.connect(
+            "value-changed", lambda adj: weak_self()._on_scroll(adj) if weak_self() else None
+        )
 
         # Content Box
         self.content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
@@ -55,7 +61,10 @@ class DiscographyPage(Adw.Bin):
         self.flow_box.set_row_spacing(0)
         self.flow_box.set_homogeneous(True)
         self.flow_box.set_activate_on_single_click(True)
-        self.flow_box.connect("child-activated", self.on_grid_child_activated)
+        weak_self = weakref.ref(self)
+        self.flow_box.connect(
+            "child-activated", lambda fb, child: weak_self().on_grid_child_activated(fb, child) if weak_self() else None
+        )
 
         self.content_box.append(self.flow_box)
 
@@ -150,39 +159,49 @@ class DiscographyPage(Adw.Bin):
             self._load_more()
 
     def _load_more(self):
+        if getattr(self, "_cleaned_up", False):
+            return
         if self._is_loading or not self._has_more:
             return
 
         self._is_loading = True
         self._loading_wrap.set_visible(True)
 
+        client = self.client
+        bid = self.browse_id
+        p = self.params
+        t_title = self.title
         def fetch_func():
+            if getattr(self, "_cleaned_up", False):
+                return
             try:
                 new_items = []
-                if self.browse_id and "Top Songs" in self.title:
+                if bid and "Top Songs" in t_title:
                     pass
-                elif self.browse_id and self.params:
+                elif bid and p:
                     # Albums, singles, videos - get_artist_albums with raw parser fallback
-                    new_items = self.client.get_artist_albums(
-                        self.browse_id, self.params, limit=100
+                    new_items = client.get_artist_albums(
+                        bid, p, limit=100
                     )
                     self._has_more = False
-                elif self.browse_id:
+                elif bid:
                     # Fallback: try as playlist, then raw parse
                     try:
-                        res = self.client.get_playlist(self.browse_id)
+                        res = client.get_playlist(bid)
                         new_items = res.get("tracks", []) if res else []
                     except Exception:
-                        new_items = self.client._raw_parse_channel_content(
-                            self.browse_id, None
+                        new_items = client._raw_parse_channel_content(
+                            bid, None
                         )
                     self._has_more = False
 
                 def update_cb():
+                    if getattr(self, "_cleaned_up", False):
+                        return
                     if new_items:
                         # Filter out items we already have
                         existing_ids = set()
-                        for item in self.items:
+                        for item in getattr(self, "items", []) or []:
                             for key in ("browseId", "videoId", "playlistId"):
                                 if item.get(key):
                                     existing_ids.add(item[key])
@@ -205,11 +224,14 @@ class DiscographyPage(Adw.Bin):
                     if not new_items:
                         self._has_more = False
 
+                if getattr(self, "_cleaned_up", False):
+                    return
                 GLib.idle_add(update_cb)
             except Exception as e:
                 print(f"Error loading discography: {e}")
-                GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
-                self._is_loading = False
+                if not getattr(self, "_cleaned_up", False):
+                    GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
+                    self._is_loading = False
 
         threading.Thread(target=fetch_func, daemon=True).start()
 
@@ -282,14 +304,16 @@ class DiscographyPage(Adw.Bin):
 
             gesture = Gtk.GestureClick()
             gesture.set_button(3)
-            gesture.connect("pressed", self.on_grid_right_click, item_box)
+            weak_self = weakref.ref(self)
+            gesture.connect(
+                "pressed", lambda g, n, x, y, : weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            )
             item_box.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed",
-                lambda g, x, y, ib=item_box: self.on_grid_right_click(g, 1, x, y, ib),
+                "pressed", lambda g, x, y, : weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(lp)
 
@@ -321,13 +345,18 @@ class DiscographyPage(Adw.Bin):
         item_box.insert_action_group("item", group)
 
         # Play Action
+        weak_self = weakref.ref(self)
         play_action = Gio.SimpleAction.new("play", None)
-        play_action.connect("activate", self._on_play_item, data)
+        play_action.connect(
+            "activate", lambda a, p, d=data: weak_self()._on_play_item(a, p, d) if weak_self() else None
+        )
         group.add_action(play_action)
 
         # Queue Action
         queue_action = Gio.SimpleAction.new("queue", None)
-        queue_action.connect("activate", self._on_queue_item, data)
+        queue_action.connect(
+            "activate", lambda a, p, d=data: weak_self()._on_queue_item(a, p, d) if weak_self() else None
+        )
         group.add_action(queue_action)
 
         def copy_json_action(action, param):
@@ -404,3 +433,50 @@ class DiscographyPage(Adw.Bin):
                 GLib.idle_add(window.player.extend_queue, tracks)
 
         threading.Thread(target=thread_func, daemon=True).start()
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources to prevent memory leaks."""
+        self._cleaned_up = True
+
+        # Disconnect scroll handler
+        if getattr(self, "_scroll_handler_id", None) is not None:
+            if hasattr(self, "scrolled") and self.scrolled:
+                try:
+                    vadjust = self.scrolled.get_vadjustment()
+                    if vadjust:
+                        vadjust.disconnect(self._scroll_handler_id)
+                except Exception:
+                    pass
+            self._scroll_handler_id = None
+
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        self.items = []
+
+        if hasattr(self, "flow_box") and self.flow_box:
+            child = self.flow_box.get_first_child()
+            while child:
+                next_child = child.get_next_sibling()
+                try:
+                    self.flow_box.remove(child)
+                except Exception:
+                    pass
+                child = next_child
+
+        if hasattr(self, "scrolled") and self.scrolled:
+            try:
+                self.scrolled.set_child(None)
+            except Exception:
+                pass
+
+        # Clear references to break reference cycles
+        self.player = None
+        self.client = None
+        self.main_box = None
+        self.scrolled = None
+        self.flow_box = None
+        self.content_box = None

--- a/src/ui/pages/history.py
+++ b/src/ui/pages/history.py
@@ -1,4 +1,5 @@
 import threading
+import weakref
 from typing import Callable
 
 from gi.repository import Gtk, Adw, GLib, Gio, Gdk, GObject, Pango
@@ -26,6 +27,8 @@ class HistoryPage(Adw.Bin):
     def __init__(self, player, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
+        weak_self = weakref.ref(self)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.client = MusicClient()
         self._tracks = []
         # Collected on each rebuild so set_compact_mode can swap the
@@ -97,7 +100,10 @@ class HistoryPage(Adw.Bin):
 
         # Title-in-headerbar behavior matches PlaylistPage so the
         # NavigationPage's title bar stays in sync when scrolling.
-        self.scrolled.get_vadjustment().connect("value-changed", self._on_scroll)
+        weak_self = weakref.ref(self)
+        self._scroll_handler_id = self.scrolled.get_vadjustment().connect(
+            "value-changed", lambda adj: weak_self()._on_scroll(adj) if weak_self() else None
+        )
 
     # ── Loading ────────────────────────────────────────────────────────────
 
@@ -139,11 +145,17 @@ class HistoryPage(Adw.Bin):
             return
 
         def _fetch():
+            if getattr(self, "_cleaned_up", False):
+                return
             tracks = self.client.get_history() or []
+            if getattr(self, "_cleaned_up", False):
+                return
             self._normalize_durations(tracks)
             GLib.idle_add(self._render, tracks)
 
         def _kick():
+            if getattr(self, "_cleaned_up", False):
+                return False
             threading.Thread(target=_fetch, daemon=True).start()
             return False
 
@@ -203,6 +215,8 @@ class HistoryPage(Adw.Bin):
         If async_render is False, all groups are rendered synchronously in a single pass
         without idle scheduling. async_callback will not be called.
         """
+        if getattr(self, "_cleaned_up", False):
+            return
         self._loading_wrap.set_visible(False)
         self._tracks = tracks
         self._row_imgs = []
@@ -274,7 +288,10 @@ class HistoryPage(Adw.Bin):
             row = self._make_row(t)
             if row is not None:
                 listbox.append(row)
-        listbox.connect("row-activated", self._on_row_activated)
+        weak_self = weakref.ref(self)
+        listbox.connect(
+            "row-activated", lambda lb, r: weak_self()._on_row_activated(lb, r) if weak_self() else None
+        )
         box.append(listbox)
         return box
 
@@ -380,18 +397,21 @@ class HistoryPage(Adw.Bin):
         like.set_valign(Gtk.Align.CENTER)
         like.set_data(vid, track.get("likeStatus", "INDIFFERENT"))
         hb.append(like)
+        row._like_btn = like
 
         row.set_child(hb)
 
         # Right-click / long-press context menu
         click = Gtk.GestureClick()
         click.set_button(3)
-        click.connect("released", self._on_row_right_click, row)
+        weak_self = weakref.ref(self)
+        click.connect(
+            "released", lambda g, n, x, y, : weak_self()._on_row_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+        )
         row.add_controller(click)
         lp = Gtk.GestureLongPress()
         lp.connect(
-            "pressed",
-            lambda g, x, y, r=row: self._on_row_right_click(g, 1, x, y, r),
+            "pressed", lambda g, x, y, : weak_self()._on_row_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
         )
         row.add_controller(lp)
 
@@ -400,6 +420,7 @@ class HistoryPage(Adw.Bin):
     # ── Interactions ───────────────────────────────────────────────────────
 
     def _on_row_activated(self, listbox, row):
+        print(f"ROW ACTIVATED: {row}")
         track = getattr(row, "_track", None)
         if not track or not self._tracks:
             return
@@ -425,10 +446,13 @@ class HistoryPage(Adw.Bin):
         group = Gio.SimpleActionGroup()
         row.insert_action_group("row", group)
         menu = Gio.Menu()
+        weak_self = weakref.ref(self)
 
         # Play
         def _do_play(a, p):
-            self._on_row_activated(None, row)
+            s = weak_self()
+            if s:
+                s._on_row_activated(None, row)
         act = Gio.SimpleAction.new("play", None)
         act.connect("activate", _do_play)
         group.add_action(act)
@@ -436,7 +460,9 @@ class HistoryPage(Adw.Bin):
 
         # Add to queue (append without taking over playback)
         def _do_queue(a, p):
-            self.player.add_to_queue(track)
+            s = weak_self()
+            if s:
+                s.player.add_to_queue(track)
         act = Gio.SimpleAction.new("queue", None)
         act.connect("activate", _do_queue)
         group.add_action(act)
@@ -449,9 +475,11 @@ class HistoryPage(Adw.Bin):
             aname = artists[0].get("name", "")
 
             def _do_artist(a, p):
-                root = self.get_root()
-                if root and hasattr(root, "open_artist"):
-                    root.open_artist(aid, aname)
+                s = weak_self()
+                if s:
+                    root = s.get_root()
+                    if root and hasattr(root, "open_artist"):
+                        root.open_artist(aid, aname)
             act = Gio.SimpleAction.new("artist", None)
             act.connect("activate", _do_artist)
             group.add_action(act)
@@ -463,9 +491,11 @@ class HistoryPage(Adw.Bin):
             alb_id = album["id"]
 
             def _do_album(a, p):
-                root = self.get_root()
-                if root and hasattr(root, "open_playlist"):
-                    root.open_playlist(alb_id)
+                s = weak_self()
+                if s:
+                    root = s.get_root()
+                    if root and hasattr(root, "open_playlist"):
+                        root.open_playlist(alb_id)
             act = Gio.SimpleAction.new("album", None)
             act.connect("activate", _do_album)
             group.add_action(act)
@@ -475,9 +505,11 @@ class HistoryPage(Adw.Bin):
         def _do_copy(a, p):
             url = f"https://music.youtube.com/watch?v={vid}"
             Gdk.Display.get_default().get_clipboard().set(url)
-            root = self.get_root()
-            if root and hasattr(root, "add_toast"):
-                root.add_toast("Link copied")
+            s = weak_self()
+            if s:
+                root = s.get_root()
+                if root and hasattr(root, "add_toast"):
+                    root.add_toast("Link copied")
         act = Gio.SimpleAction.new("copy_link", None)
         act.connect("activate", _do_copy)
         group.add_action(act)
@@ -499,7 +531,9 @@ class HistoryPage(Adw.Bin):
             )
 
             def _do_remove(a, p):
-                self._remove_track_optimistic(vid, tokens)
+                s = weak_self()
+                if s:
+                    s._remove_track_optimistic(vid, tokens)
             act = Gio.SimpleAction.new("remove_history", None)
             act.connect("activate", _do_remove)
             group.add_action(act)
@@ -563,9 +597,11 @@ class HistoryPage(Adw.Bin):
             self.empty_label.set_visible(True)
 
         # 4. Fire the API call.
+        client = self.client
         def _th():
             try:
-                self.client.remove_history_items(tokens)
+                if client:
+                    client.remove_history_items(tokens)
             except Exception as e:
                 print(f"[HISTORY] remove failed: {e}")
 
@@ -592,3 +628,53 @@ class HistoryPage(Adw.Bin):
             self.remove_css_class("compact")
             self.content_box.set_margin_start(24)
             self.content_box.set_margin_end(24)
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources to prevent memory leaks."""
+        self._cleaned_up = True
+
+        # Disconnect scroll handler
+        if getattr(self, "_scroll_handler_id", None) is not None:
+            if hasattr(self, "scrolled") and self.scrolled:
+                try:
+                    self.scrolled.get_vadjustment().disconnect(self._scroll_handler_id)
+                except Exception:
+                    pass
+            self._scroll_handler_id = None
+
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        self._tracks = []
+        self._row_imgs = []
+
+        if hasattr(self, "sections_box") and self.sections_box:
+            child = self.sections_box.get_first_child()
+            while child:
+                next_child = child.get_next_sibling()
+                try:
+                    self.sections_box.remove(child)
+                except Exception:
+                    pass
+                child = next_child
+
+        if hasattr(self, "scrolled") and self.scrolled:
+            try:
+                self.scrolled.set_child(None)
+            except Exception:
+                pass
+
+        # Clear references to break GObject reference cycles
+        self.player = None
+        self.client = None
+        self.main_box = None
+        self.scrolled = None
+        self.clamp = None
+        self.content_box = None
+        self.title_label = None
+        self.sections_box = None
+        self.empty_label = None
+        self._loading_wrap = None

--- a/src/ui/pages/history.py
+++ b/src/ui/pages/history.py
@@ -28,7 +28,6 @@ class HistoryPage(Adw.Bin):
         super().__init__(*args, **kwargs)
         self.player = player
         weak_self = weakref.ref(self)
-        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.client = MusicClient()
         self._tracks = []
         # Collected on each rebuild so set_compact_mode can swap the
@@ -145,17 +144,11 @@ class HistoryPage(Adw.Bin):
             return
 
         def _fetch():
-            if getattr(self, "_cleaned_up", False):
-                return
             tracks = self.client.get_history() or []
-            if getattr(self, "_cleaned_up", False):
-                return
             self._normalize_durations(tracks)
             GLib.idle_add(self._render, tracks)
 
         def _kick():
-            if getattr(self, "_cleaned_up", False):
-                return False
             threading.Thread(target=_fetch, daemon=True).start()
             return False
 
@@ -215,8 +208,6 @@ class HistoryPage(Adw.Bin):
         If async_render is False, all groups are rendered synchronously in a single pass
         without idle scheduling. async_callback will not be called.
         """
-        if getattr(self, "_cleaned_up", False):
-            return
         self._loading_wrap.set_visible(False)
         self._tracks = tracks
         self._row_imgs = []
@@ -406,12 +397,12 @@ class HistoryPage(Adw.Bin):
         click.set_button(3)
         weak_self = weakref.ref(self)
         click.connect(
-            "released", lambda g, n, x, y, : weak_self()._on_row_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            "released", lambda g, n, x, y: weak_self()._on_row_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
         )
         row.add_controller(click)
         lp = Gtk.GestureLongPress()
         lp.connect(
-            "pressed", lambda g, x, y, : weak_self()._on_row_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            "pressed", lambda g, x, y: weak_self()._on_row_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
         )
         row.add_controller(lp)
 
@@ -420,7 +411,6 @@ class HistoryPage(Adw.Bin):
     # ── Interactions ───────────────────────────────────────────────────────
 
     def _on_row_activated(self, listbox, row):
-        print(f"ROW ACTIVATED: {row}")
         track = getattr(row, "_track", None)
         if not track or not self._tracks:
             return
@@ -629,52 +619,3 @@ class HistoryPage(Adw.Bin):
             self.content_box.set_margin_start(24)
             self.content_box.set_margin_end(24)
 
-    def _on_page_destroy(self, widget):
-        self.cleanup()
-
-    def cleanup(self):
-        """Clean up resources to prevent memory leaks."""
-        self._cleaned_up = True
-
-        # Disconnect scroll handler
-        if getattr(self, "_scroll_handler_id", None) is not None:
-            if hasattr(self, "scrolled") and self.scrolled:
-                try:
-                    self.scrolled.get_vadjustment().disconnect(self._scroll_handler_id)
-                except Exception:
-                    pass
-            self._scroll_handler_id = None
-
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        self._tracks = []
-        self._row_imgs = []
-
-        if hasattr(self, "sections_box") and self.sections_box:
-            child = self.sections_box.get_first_child()
-            while child:
-                next_child = child.get_next_sibling()
-                try:
-                    self.sections_box.remove(child)
-                except Exception:
-                    pass
-                child = next_child
-
-        if hasattr(self, "scrolled") and self.scrolled:
-            try:
-                self.scrolled.set_child(None)
-            except Exception:
-                pass
-
-        # Clear references to break GObject reference cycles
-        self.player = None
-        self.client = None
-        self.main_box = None
-        self.scrolled = None
-        self.clamp = None
-        self.content_box = None
-        self.title_label = None
-        self.sections_box = None
-        self.empty_label = None
-        self._loading_wrap = None

--- a/src/ui/pages/library.py
+++ b/src/ui/pages/library.py
@@ -1,3 +1,4 @@
+import weakref
 import os
 import json as _json
 from gi.repository import Gtk, Adw, GObject, GLib, Gdk, Gio, Pango
@@ -1067,7 +1068,7 @@ class LibraryPage(Adw.Bin):
                 lp = Gtk.GestureLongPress()
                 lp.connect(
                     "pressed",
-                    lambda g, x, y, r=row: self.on_row_right_click(g, 1, x, y, r),
+                    lambda g, x, y, : self.on_row_right_click(g, 1, x, y, g.get_widget()),
                 )
                 row.add_controller(lp)
 
@@ -1185,7 +1186,7 @@ class LibraryPage(Adw.Bin):
                 lp = Gtk.GestureLongPress()
                 lp.connect(
                     "pressed",
-                    lambda g, x, y, r=row: self.on_album_right_click(g, 1, x, y, r),
+                    lambda g, x, y, : self.on_album_right_click(g, 1, x, y, g.get_widget()),
                 )
                 row.add_controller(lp)
 
@@ -2130,7 +2131,7 @@ class UploadsPage(Gtk.Box):
             row.add_controller(gesture)
 
             lp = Gtk.GestureLongPress()
-            lp.connect("pressed", lambda g, x, y, r=row: self._on_album_right_click(g, 1, x, y, r))
+            lp.connect("pressed", lambda g, x, y, : self._on_album_right_click(g, 1, x, y, g.get_widget()))
             row.add_controller(lp)
 
             self.albums_list.append(row)

--- a/src/ui/pages/library.py
+++ b/src/ui/pages/library.py
@@ -206,7 +206,8 @@ class LibraryPage(Adw.Bin):
         self.all_songs_btn.add_css_class("circular")
         self.all_songs_btn.set_valign(Gtk.Align.CENTER)
         self.all_songs_btn.set_tooltip_text("All Uploaded Songs")
-        self.all_songs_btn.connect("clicked", lambda b: self.uploads_page._open_all_songs())
+        weak_self = weakref.ref(self)
+        self.all_songs_btn.connect("clicked", lambda b: weak_self().uploads_page._open_all_songs() if weak_self() else None)
         self.uploads_actions_box.append(self.all_songs_btn)
 
         tab_row.append(self.uploads_actions_box)
@@ -1068,7 +1069,7 @@ class LibraryPage(Adw.Bin):
                 lp = Gtk.GestureLongPress()
                 lp.connect(
                     "pressed",
-                    lambda g, x, y, : self.on_row_right_click(g, 1, x, y, g.get_widget()),
+                    lambda g, x, y, ws=weakref.ref(self): ws().on_row_right_click(g, 1, x, y, g.get_widget()) if ws() else None,
                 )
                 row.add_controller(lp)
 
@@ -1186,7 +1187,7 @@ class LibraryPage(Adw.Bin):
                 lp = Gtk.GestureLongPress()
                 lp.connect(
                     "pressed",
-                    lambda g, x, y, : self.on_album_right_click(g, 1, x, y, g.get_widget()),
+                    lambda g, x, y, ws=weakref.ref(self): ws().on_album_right_click(g, 1, x, y, g.get_widget()) if ws() else None,
                 )
                 row.add_controller(lp)
 
@@ -2131,7 +2132,7 @@ class UploadsPage(Gtk.Box):
             row.add_controller(gesture)
 
             lp = Gtk.GestureLongPress()
-            lp.connect("pressed", lambda g, x, y, : self._on_album_right_click(g, 1, x, y, g.get_widget()))
+            lp.connect("pressed", lambda g, x, y, ws=weakref.ref(self): ws()._on_album_right_click(g, 1, x, y, g.get_widget()) if ws() else None)
             row.add_controller(lp)
 
             self.albums_list.append(row)
@@ -2266,7 +2267,7 @@ class UploadsPage(Gtk.Box):
             title = album.get("title", "this album")
             action_section.append("Delete Album", "upl.delete")
             a_del = Gio.SimpleAction.new("delete", None)
-            a_del.connect("activate", lambda a, p, eid=entity_id, t=title: self._confirm_delete_upload(eid, t))
+            a_del.connect("activate", lambda a, p, eid=entity_id, t=title, ws=weakref.ref(self): ws()._confirm_delete_upload(eid, t) if ws() else None)
             group.add_action(a_del)
 
         if action_section.get_n_items() > 0:

--- a/src/ui/pages/mix.py
+++ b/src/ui/pages/mix.py
@@ -38,8 +38,6 @@ class MixPage(BasePlaylistPage):
         thread.start()
 
     def _fetch_details(self, is_incremental=False):
-        if getattr(self, "_cleaned_up", False):
-            return
         client = self.client
         pid = self.playlist_id
         if not client or not pid:
@@ -47,8 +45,6 @@ class MixPage(BasePlaylistPage):
         try:
             # ytmusicapi get_playlist with limit=25 initially
             data = client.get_playlist(pid, limit=100)
-            if getattr(self, "_cleaned_up", False):
-                return
 
             title = data.get("title", "Unknown Mix")
             description = data.get("description", "")
@@ -58,8 +54,6 @@ class MixPage(BasePlaylistPage):
             meta1 = "Auto-generated Mix"
             meta2 = "Infinite Playlist"
 
-            if getattr(self, "_cleaned_up", False):
-                return
             GObject.idle_add(
                 self.update_ui, title, description, meta1, meta2, thumbnails, tracks
             )
@@ -89,5 +83,3 @@ class MixPage(BasePlaylistPage):
         self.load_more_spinner.set_visible(False)
         self.is_loading_more = False
 
-    def cleanup(self):
-        super().cleanup()

--- a/src/ui/pages/mix.py
+++ b/src/ui/pages/mix.py
@@ -38,9 +38,17 @@ class MixPage(BasePlaylistPage):
         thread.start()
 
     def _fetch_details(self, is_incremental=False):
+        if getattr(self, "_cleaned_up", False):
+            return
+        client = self.client
+        pid = self.playlist_id
+        if not client or not pid:
+            return
         try:
             # ytmusicapi get_playlist with limit=25 initially
-            data = self.client.get_playlist(self.playlist_id, limit=100)
+            data = client.get_playlist(pid, limit=100)
+            if getattr(self, "_cleaned_up", False):
+                return
 
             title = data.get("title", "Unknown Mix")
             description = data.get("description", "")
@@ -50,6 +58,8 @@ class MixPage(BasePlaylistPage):
             meta1 = "Auto-generated Mix"
             meta2 = "Infinite Playlist"
 
+            if getattr(self, "_cleaned_up", False):
+                return
             GObject.idle_add(
                 self.update_ui, title, description, meta1, meta2, thumbnails, tracks
             )
@@ -78,3 +88,6 @@ class MixPage(BasePlaylistPage):
         # self.sort_row.set_visible(False)
         self.load_more_spinner.set_visible(False)
         self.is_loading_more = False
+
+    def cleanup(self):
+        super().cleanup()

--- a/src/ui/pages/mood.py
+++ b/src/ui/pages/mood.py
@@ -1,5 +1,6 @@
 from gi.repository import Gtk, Adw, GObject, GLib, Gio, Pango, Gdk
 import threading
+import weakref
 from api.client import MusicClient
 from ui.utils import AsyncImage
 from ui.util_classes import ScrolledWindow
@@ -13,6 +14,8 @@ class MoodPage(Adw.Bin):
     def __init__(self, player, open_playlist_callback, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
+        weak_self = weakref.ref(self)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.params = None
@@ -45,7 +48,10 @@ class MoodPage(Adw.Bin):
         self.flow_box.set_row_spacing(0)
         self.flow_box.set_homogeneous(True)
         self.flow_box.set_activate_on_single_click(True)
-        self.flow_box.connect("child-activated", self.on_grid_child_activated)
+        weak_self = weakref.ref(self)
+        self.flow_box.connect(
+            "child-activated", lambda fb, child: weak_self().on_grid_child_activated(fb, child) if weak_self() else None
+        )
 
         self.content_box.append(self.flow_box)
 
@@ -100,17 +106,25 @@ class MoodPage(Adw.Bin):
 
 
     def _load_data(self):
+        if getattr(self, "_cleaned_up", False):
+            return
         if self._is_loading:
             return
 
         self._is_loading = True
         self._loading_wrap.set_visible(True)
 
+        client = self.client
+        p = self.params
         def fetch_func():
+            if getattr(self, "_cleaned_up", False):
+                return
             try:
-                new_items = self.client.get_mood_playlists(self.params)
+                new_items = client.get_mood_playlists(p)
 
                 def update_cb():
+                    if getattr(self, "_cleaned_up", False):
+                        return
                     if new_items:
                         self.items.extend(new_items)
                         self._render_items(new_items)
@@ -118,11 +132,14 @@ class MoodPage(Adw.Bin):
                     self._is_loading = False
                     self._loading_wrap.set_visible(False)
 
+                if getattr(self, "_cleaned_up", False):
+                    return
                 GLib.idle_add(update_cb)
             except Exception as e:
                 print(f"Error loading mood playlists: {e}")
-                GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
-                self._is_loading = False
+                if not getattr(self, "_cleaned_up", False):
+                    GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
+                    self._is_loading = False
 
         threading.Thread(target=fetch_func, daemon=True).start()
 
@@ -163,14 +180,16 @@ class MoodPage(Adw.Bin):
 
             gesture = Gtk.GestureClick()
             gesture.set_button(3)
-            gesture.connect("pressed", self.on_grid_right_click, item_box)
+            weak_self = weakref.ref(self)
+            gesture.connect(
+                "pressed", lambda g, n, x, y, : weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            )
             item_box.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed",
-                lambda g, x, y, ib=item_box: self.on_grid_right_click(g, 1, x, y, ib),
+                "pressed", lambda g, x, y, : weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(lp)
 
@@ -193,13 +212,18 @@ class MoodPage(Adw.Bin):
         item_box.insert_action_group("item", group)
 
         # Play Action
+        weak_self = weakref.ref(self)
         play_action = Gio.SimpleAction.new("play", None)
-        play_action.connect("activate", self._on_play_item, data)
+        play_action.connect(
+            "activate", lambda a, p, d=data: weak_self()._on_play_item(a, p, d) if weak_self() else None
+        )
         group.add_action(play_action)
 
         # Queue Action
         queue_action = Gio.SimpleAction.new("queue", None)
-        queue_action.connect("activate", self._on_queue_item, data)
+        queue_action.connect(
+            "activate", lambda a, p, d=data: weak_self()._on_queue_item(a, p, d) if weak_self() else None
+        )
         group.add_action(queue_action)
 
         menu = Gio.Menu()
@@ -252,3 +276,38 @@ class MoodPage(Adw.Bin):
                 GLib.idle_add(window.player.extend_queue, tracks)
 
         threading.Thread(target=thread_func, daemon=True).start()
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources to prevent memory leaks."""
+        self._cleaned_up = True
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        self.items = []
+
+        if hasattr(self, "flow_box") and self.flow_box:
+            child = self.flow_box.get_first_child()
+            while child:
+                next_child = child.get_next_sibling()
+                try:
+                    self.flow_box.remove(child)
+                except Exception:
+                    pass
+                child = next_child
+
+        if hasattr(self, "scrolled") and self.scrolled:
+            try:
+                self.scrolled.set_child(None)
+            except Exception:
+                pass
+
+        # Clear references to break reference cycles
+        self.player = None
+        self.client = None
+        self.main_box = None
+        self.scrolled = None
+        self.flow_box = None
+        self.content_box = None

--- a/src/ui/pages/mood.py
+++ b/src/ui/pages/mood.py
@@ -15,7 +15,6 @@ class MoodPage(Adw.Bin):
         super().__init__(*args, **kwargs)
         self.player = player
         weak_self = weakref.ref(self)
-        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.open_playlist_callback = open_playlist_callback
         self.client = MusicClient()
         self.params = None
@@ -106,8 +105,6 @@ class MoodPage(Adw.Bin):
 
 
     def _load_data(self):
-        if getattr(self, "_cleaned_up", False):
-            return
         if self._is_loading:
             return
 
@@ -117,14 +114,10 @@ class MoodPage(Adw.Bin):
         client = self.client
         p = self.params
         def fetch_func():
-            if getattr(self, "_cleaned_up", False):
-                return
             try:
                 new_items = client.get_mood_playlists(p)
 
                 def update_cb():
-                    if getattr(self, "_cleaned_up", False):
-                        return
                     if new_items:
                         self.items.extend(new_items)
                         self._render_items(new_items)
@@ -132,14 +125,11 @@ class MoodPage(Adw.Bin):
                     self._is_loading = False
                     self._loading_wrap.set_visible(False)
 
-                if getattr(self, "_cleaned_up", False):
-                    return
                 GLib.idle_add(update_cb)
             except Exception as e:
                 print(f"Error loading mood playlists: {e}")
-                if not getattr(self, "_cleaned_up", False):
-                    GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
-                    self._is_loading = False
+                GLib.idle_add(lambda: self._loading_wrap.set_visible(False))
+                self._is_loading = False
 
         threading.Thread(target=fetch_func, daemon=True).start()
 
@@ -182,14 +172,14 @@ class MoodPage(Adw.Bin):
             gesture.set_button(3)
             weak_self = weakref.ref(self)
             gesture.connect(
-                "pressed", lambda g, n, x, y, : weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, n, x, y: weak_self().on_grid_right_click(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(gesture)
 
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, : weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+                "pressed", lambda g, x, y: weak_self().on_grid_right_click(g, 1, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
             )
             item_box.add_controller(lp)
 
@@ -276,38 +266,3 @@ class MoodPage(Adw.Bin):
                 GLib.idle_add(window.player.extend_queue, tracks)
 
         threading.Thread(target=thread_func, daemon=True).start()
-
-    def _on_page_destroy(self, widget):
-        self.cleanup()
-
-    def cleanup(self):
-        """Clean up resources to prevent memory leaks."""
-        self._cleaned_up = True
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        self.items = []
-
-        if hasattr(self, "flow_box") and self.flow_box:
-            child = self.flow_box.get_first_child()
-            while child:
-                next_child = child.get_next_sibling()
-                try:
-                    self.flow_box.remove(child)
-                except Exception:
-                    pass
-                child = next_child
-
-        if hasattr(self, "scrolled") and self.scrolled:
-            try:
-                self.scrolled.set_child(None)
-            except Exception:
-                pass
-
-        # Clear references to break reference cycles
-        self.player = None
-        self.client = None
-        self.main_box = None
-        self.scrolled = None
-        self.flow_box = None
-        self.content_box = None

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -422,7 +422,9 @@ class PlaylistPage(Adw.Bin):
         self.header_store.append(HeaderItem())
 
         self.track_store = Gio.ListStore(item_type=TrackItem)
-        self.track_filter = Gtk.CustomFilter.new(self._track_filter_func, None)
+        self.track_filter = Gtk.CustomFilter.new(
+            lambda item, user_data: weak_self()._track_filter_func(item, user_data) if weak_self() else False, None
+        )
         # Start with no filter attached — Gtk.FilterListModel calls its filter
         # callback (Python!) for every item on every items-changed, which for
         # 989-track playlists meant ~1000 Python↔C crossings *per splice* even
@@ -625,14 +627,12 @@ class PlaylistPage(Adw.Bin):
         left_click.set_button(1)
         weak_self = weakref.ref(self)
         left_click.connect(
-            "pressed", lambda g, n, x, y, : weak_self()._on_row_left_pressed(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+            "pressed", lambda g, n, x, y: weak_self()._on_row_left_pressed(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
         )
         left_click.connect(
             "released", lambda g, n, x, y, li=list_item: weak_self()._on_row_left_click(g, n, x, y, li) if weak_self() else None
         )
         row.add_controller(left_click)
-
-        row._lv_list_item_ref = weakref.ref(list_item)
 
         row._lv_video_data = None
         row._lv_full_track = None
@@ -716,9 +716,10 @@ class PlaylistPage(Adw.Bin):
             if hasattr(row, "_lv_check_handler") and row._lv_check_handler:
                 check.disconnect(row._lv_check_handler)
             check.set_active(is_selected)
+            weak_self = weakref.ref(self)
             row._lv_check_handler = check.connect(
                 "toggled",
-                lambda cb, vid=video_id, : self._toggle_track_selection(vid, g.get_widget()),
+                lambda cb, vid=video_id, r=weakref.ref(row): weak_self()._toggle_track_selection(vid, r()) if weak_self() else None,
             )
         elif row._lv_check is not None:
             row._lv_check.set_visible(False)
@@ -876,6 +877,7 @@ class PlaylistPage(Adw.Bin):
             return
 
         row = bin_widget._lv_track_ui
+        row.insert_action_group("ctx", None)
         # Disconnect player signal
         if row._lv_player_handler is not None:
             try:
@@ -1094,7 +1096,6 @@ class PlaylistPage(Adw.Bin):
         # chunker from a previous render so its scheduled appends get
         # dropped instead of mutating the freshly-cleared store.
         self._track_populate_token = getattr(self, "_track_populate_token", 0) + 1
-
     def _populate_tracks_chunked(self, tracks, first_batch=40, batch=80):
         """Fill the track store without blocking the main thread.
 
@@ -1113,8 +1114,6 @@ class PlaylistPage(Adw.Bin):
         full population (update_ui's non-append branch, reorder_playlist).
         Do NOT mix with other code that splices in parallel — the tail
         splices use `track_store.get_n_items()` and will race."""
-        if getattr(self, "_cleaned_up", False):
-            return
         self._clear_track_store()
         if not tracks:
             return
@@ -1125,8 +1124,6 @@ class PlaylistPage(Adw.Bin):
             return
 
         def pump(cursor):
-            if getattr(self, "_cleaned_up", False):
-                return False
             if token != self._track_populate_token:
                 return False  # superseded
             end = min(cursor + batch, len(tracks))
@@ -1512,54 +1509,6 @@ class PlaylistPage(Adw.Bin):
                 pass
             self._dl_done_id = None
 
-        # Clear track store
-        if hasattr(self, "track_store") and self.track_store:
-            try:
-                self.track_store.remove_all()
-            except Exception:
-                pass
-
-        self.current_tracks = []
-        self.original_tracks = []
-
-        # Recursively cleanup image widgets to cancel pending async loads
-        from ui.utils import cleanup_widget_images
-        cleanup_widget_images(self)
-
-        # Clear references to break reference cycles
-        self.player = None
-        self.client = None
-        self.header_container = None
-        self.header_info_box = None
-        self.cover_img = None
-        self.cover_wrapper = None
-        self.details_col = None
-        self.playlist_name_label = None
-        self.description_label = None
-        self.read_more_btn = None
-        self.desc_box = None
-        self.meta_label = None
-        self.stats_label = None
-        self.actions_box = None
-        self.more_btn = None
-        self.more_menu = None
-        self.sort_row = None
-        self.sort_dropdown = None
-        self.sort_dir_btn = None
-        self.select_btn = None
-        self.selection_bar = None
-        self.selection_label = None
-        self.sel_add_btn = None
-        self.sel_remove_btn = None
-        self.songs_list = None
-        self.vadjust = None
-        self.content_spinner = None
-        self.load_more_spinner = None
-        self.stack = None
-        self.main_box = None
-        self.selection_model = None
-        self.track_store = None
-
     # ── Load playlist ─────────────────────────────────────────────────────────
 
     # Delay the live-data refresh when we already have something to show.
@@ -1776,8 +1725,6 @@ class PlaylistPage(Adw.Bin):
     def _apply_disk_cache_header(self, token, payload):
         """Cheap header updates: title, description, meta strings, cover.
         Safe to run during the page-push animation."""
-        if getattr(self, "_cleaned_up", False):
-            return False
         if token != getattr(self, "_track_populate_token", 0):
             return False
         try:
@@ -1841,8 +1788,6 @@ class PlaylistPage(Adw.Bin):
         Worker has already done JSON parse + TrackItem construction; the
         main thread only owes the splice itself.
         """
-        if getattr(self, "_cleaned_up", False):
-            return False
         if token != getattr(self, "_track_populate_token", 0):
             return False
         try:
@@ -1892,8 +1837,6 @@ class PlaylistPage(Adw.Bin):
         # sees as a hard stutter right after the page opens. Splice in
         # smaller chunks with idle yields between so layout/paint can
         # interleave — total work is the same, but spread across frames.
-        if getattr(self, "_cleaned_up", False):
-            return False
         if token != getattr(self, "_track_populate_token", 0):
             return False
         try:
@@ -2491,8 +2434,6 @@ class PlaylistPage(Adw.Bin):
         total_tracks=None,
         is_owned=False,
     ):
-        if getattr(self, "_cleaned_up", False):
-            return
         self.stack.set_visible_child_name("content")
         self.content_spinner.set_visible(False)
 
@@ -2643,29 +2584,21 @@ class PlaylistPage(Adw.Bin):
     def _start_background_full_fetch(self):
         if getattr(self, "is_fully_fetched", False):
             return
-        if getattr(self, "_cleaned_up", False):
-            return
         print(f"Starting background fetch for full playlist: {self.playlist_id}")
 
         client = self.client
         pid = self.playlist_id
         def fetch_job():
-            if getattr(self, "_cleaned_up", False):
-                return
             try:
                 # get_playlist_full handles the full fetch and (via
                 # MusicClient.get_playlist_full) owns the disk-cache
                 # write once ytmusicapi / raw-continuation / yt_dlp have
                 # done their best. No cache logic here.
                 data = client.get_playlist_full(pid, limit=None)
-                if getattr(self, "_cleaned_up", False):
-                    return
                 tracks = data.get("tracks", []) if data else []
                 if tracks:
                     print(f"Background fetch complete. Fetched {len(tracks)} tracks.")
                     client.set_cached_playlist_tracks(pid, tracks)
-                    if getattr(self, "_cleaned_up", False):
-                        return
                     GObject.idle_add(self._on_background_fetch_complete, tracks)
             except Exception as e:
                 print(f"Error in background fetch: {e}")
@@ -2677,8 +2610,6 @@ class PlaylistPage(Adw.Bin):
         thread.start()
 
     def _on_background_fetch_complete(self, tracks=None):
-        if getattr(self, "_cleaned_up", False):
-            return
         if tracks is not None:
             self.original_tracks = tracks
         self.is_fully_fetched = True
@@ -2855,9 +2786,10 @@ class PlaylistPage(Adw.Bin):
                 else None
             )
             if vid:
+                weak_self = weakref.ref(self)
                 row._lv_check_handler = check.connect(
                     "toggled",
-                    lambda cb, v=vid, : self._toggle_track_selection(v, g.get_widget()),
+                    lambda cb, v=vid, r=weakref.ref(row): weak_self()._toggle_track_selection(v, r()) if weak_self() else None,
                 )
 
     def _refresh_all_row_visuals(self):
@@ -3457,18 +3389,19 @@ class PlaylistPage(Adw.Bin):
             sel_section.append("Deselect All", "ctx.deselect_all")
 
             a_toggle = Gio.SimpleAction.new("toggle_sel", None)
+            weak_self = weakref.ref(self)
             a_toggle.connect(
                 "activate",
-                lambda act, p, v=vid, : self._toggle_track_selection(v, g.get_widget()),
+                lambda act, p, v=vid, r=weakref.ref(row): weak_self()._toggle_track_selection(v, r()) if weak_self() else None,
             )
             group.add_action(a_toggle)
 
             a_sel_all = Gio.SimpleAction.new("select_all", None)
-            a_sel_all.connect("activate", lambda act, p: self._select_all())
+            a_sel_all.connect("activate", lambda act, p: weak_self()._select_all() if weak_self() else None)
             group.add_action(a_sel_all)
 
             a_desel = Gio.SimpleAction.new("deselect_all", None)
-            a_desel.connect("activate", lambda act, p: self._deselect_all())
+            a_desel.connect("activate", lambda act, p: weak_self()._deselect_all() if weak_self() else None)
             group.add_action(a_desel)
 
             menu_model.append_section(None, sel_section)
@@ -3491,7 +3424,8 @@ class PlaylistPage(Adw.Bin):
         if self._multi_select_mode and self._selected_video_ids:
             clip_section.append("Copy Selection Data (Debug)", "ctx.copy_debug")
             a_debug = Gio.SimpleAction.new("copy_debug", None)
-            a_debug.connect("activate", lambda act, p: self._copy_selection_debug())
+            weak_self = weakref.ref(self)
+            a_debug.connect("activate", lambda act, p: weak_self()._copy_selection_debug() if weak_self() else None)
             group.add_action(a_debug)
 
         if clip_section.get_n_items() > 0:
@@ -3533,7 +3467,8 @@ class PlaylistPage(Adw.Bin):
         self.read_more_btn.set_markup(f"<a href='toggle'>{text}</a>")
         self.read_more_btn.add_css_class("caption")
         self.read_more_btn.set_halign(Gtk.Align.START)
-        self.read_more_btn.connect("activate-link", self._on_read_more_clicked)
+        weak_self = weakref.ref(self)
+        self.read_more_btn.connect("activate-link", lambda label, uri: weak_self()._on_read_more_clicked(label, uri) if weak_self() else False)
         parent.append(self.read_more_btn)
         return False
 
@@ -3693,8 +3628,6 @@ class PlaylistPage(Adw.Bin):
         self.load_playlist(pid)
 
     def _reshow_virtual(self, title, tracks, meta1):
-        if getattr(self, "_cleaned_up", False):
-            return
         self.original_tracks = tracks
         self.current_tracks = tracks
         total_seconds = sum(t.get("duration_seconds", 0) or 0 for t in tracks)
@@ -3809,7 +3742,8 @@ class PlaylistPage(Adw.Bin):
         if can_edit:
             action = Gio.SimpleAction.new("edit_playlist", None)
             action.set_enabled(True)
-            action.connect("activate", lambda *_: self._show_edit_dialog())
+            weak_self = weakref.ref(self)
+            action.connect("activate", lambda *_: weak_self()._show_edit_dialog() if weak_self() else None)
             group.add_action(action)
 
         self.cover_wrapper.insert_action_group("cover", group)

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -1,7 +1,9 @@
 import threading
+import weakref
 import os
 import shutil
 import tempfile
+import re
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gdk, Gio, GdkPixbuf
 from api.client import MusicClient
 from ui.utils import AsyncImage, LikeButton, get_yt_music_link, show_toast
@@ -37,8 +39,10 @@ class PlaylistPage(Adw.Bin):
     def __init__(self, player, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.player = player
-        self.connect("map", self._on_map)
-        self.connect("unmap", self._on_unmap)
+        weak_self = weakref.ref(self)
+        self.connect("map", lambda w: weak_self()._on_map(w) if weak_self() else None)
+        self.connect("unmap", lambda w: weak_self()._on_unmap(w) if weak_self() else None)
+        self.connect("destroy", lambda w: weak_self()._on_page_destroy(w) if weak_self() else None)
         self.client = MusicClient()
         self.playlist_id = None
         self.playlist_title_text = ""
@@ -70,12 +74,16 @@ class PlaylistPage(Adw.Bin):
 
         cover_gesture = Gtk.GestureClick()
         cover_gesture.set_button(3)
-        cover_gesture.connect("pressed", self.on_cover_right_click)
+        cover_gesture.connect(
+            "pressed", lambda g, n, x, y: weak_self().on_cover_right_click(g, n, x, y) if weak_self() else None
+        )
         self.cover_wrapper.add_controller(cover_gesture)
 
         # Long Press for touch
         lp = Gtk.GestureLongPress()
-        lp.connect("pressed", lambda g, x, y: self.on_cover_right_click(g, 1, x, y))
+        lp.connect(
+            "pressed", lambda g, x, y: weak_self().on_cover_right_click(g, 1, x, y) if weak_self() else None
+        )
         self.cover_wrapper.add_controller(lp)
 
         self.details_col = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
@@ -111,7 +119,9 @@ class PlaylistPage(Adw.Bin):
         self.read_more_btn.add_css_class("caption")
         self.read_more_btn.set_halign(Gtk.Align.START)
         self.read_more_btn.set_visible(False)
-        self.read_more_btn.connect("activate-link", self._on_read_more_clicked)
+        self.read_more_btn.connect(
+            "activate-link", lambda label, uri: weak_self()._on_read_more_clicked(label, uri) if weak_self() else None
+        )
 
         # Group description + read more tightly without extra spacing
         self.desc_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -128,7 +138,9 @@ class PlaylistPage(Adw.Bin):
         self.meta_label.set_halign(Gtk.Align.START)
         self.meta_label.set_hexpand(True)
         self.meta_label.set_use_markup(True)
-        self.meta_label.connect("activate-link", self.on_meta_link_activated)
+        self.meta_label.connect(
+            "activate-link", lambda label, uri: weak_self().on_meta_link_activated(label, uri) if weak_self() else None
+        )
         self.details_col.append(self.meta_label)
 
         self.stats_label = Gtk.Label(label="")
@@ -147,7 +159,7 @@ class PlaylistPage(Adw.Bin):
         play_btn = Gtk.Button(label="Play")
         play_btn.add_css_class("suggested-action")
         play_btn.add_css_class("pill")
-        play_btn.connect("clicked", self.on_play_clicked)
+        play_btn.connect("clicked", lambda btn: weak_self().on_play_clicked(btn) if weak_self() else None)
         actions_box.append(play_btn)
 
         shuffle_btn = Gtk.Button()
@@ -156,7 +168,7 @@ class PlaylistPage(Adw.Bin):
         shuffle_btn.set_valign(Gtk.Align.CENTER)
         shuffle_btn.set_halign(Gtk.Align.CENTER)
         shuffle_btn.set_size_request(48, 48)
-        shuffle_btn.connect("clicked", self.on_shuffle_clicked)
+        shuffle_btn.connect("clicked", lambda btn: weak_self().on_shuffle_clicked(btn) if weak_self() else None)
         actions_box.append(shuffle_btn)
 
         # Simplified Actions (Play/Shuffle only)
@@ -178,7 +190,9 @@ class PlaylistPage(Adw.Bin):
         # popover is actually about to appear.
         self._more_menu_dirty = True
         self._more_menu_pending_is_owned = False
-        self.more_btn.connect("notify::active", self._on_more_btn_active)
+        self.more_btn.connect(
+            "notify::active", lambda mb, spec: weak_self()._on_more_btn_active(mb, spec) if weak_self() else None
+        )
         actions_box.append(self.more_btn)
 
         # Actions Row
@@ -188,61 +202,89 @@ class PlaylistPage(Adw.Bin):
         action_add = Gio.SimpleAction.new(
             "add_all_to_playlist", GLib.VariantType.new("s")
         )
-        action_add.connect("activate", self._on_add_all_to_playlist)
+        action_add.connect(
+            "activate", lambda a, p: weak_self()._on_add_all_to_playlist(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_add)
 
         action_show_add = Gio.SimpleAction.new("show_add_all_to_playlist", None)
-        action_show_add.connect("activate", self._on_show_add_all_to_playlist)
+        action_show_add.connect(
+            "activate", lambda a, p: weak_self()._on_show_add_all_to_playlist(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_show_add)
 
         action_sel_all = Gio.SimpleAction.new("sel_all", None)
-        action_sel_all.connect("activate", lambda a, p: self._select_all())
+        action_sel_all.connect(
+            "activate", lambda a, p: weak_self()._select_all() if weak_self() else None
+        )
         self.action_group.add_action(action_sel_all)
 
         action_sel_none = Gio.SimpleAction.new("sel_none", None)
-        action_sel_none.connect("activate", lambda a, p: self._deselect_all())
+        action_sel_none.connect(
+            "activate", lambda a, p: weak_self()._deselect_all() if weak_self() else None
+        )
         self.action_group.add_action(action_sel_none)
 
         action_copy = Gio.SimpleAction.new("copy_link", None)
-        action_copy.connect("activate", self.on_copy_link_clicked)
+        action_copy.connect(
+            "activate", lambda a, p: weak_self().on_copy_link_clicked(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_copy)
 
         action_edit = Gio.SimpleAction.new("edit", None)
-        action_edit.connect("activate", self.on_edit_clicked)
+        action_edit.connect(
+            "activate", lambda a, p: weak_self().on_edit_clicked(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_edit)
 
         action_delete = Gio.SimpleAction.new("delete", None)
-        action_delete.connect("activate", self.on_delete_clicked)
+        action_delete.connect(
+            "activate", lambda a, p: weak_self().on_delete_clicked(a, p) if weak_self() else None
+        )
 
         action_sel_add = Gio.SimpleAction.new(
             "sel_add_to_playlist", GLib.VariantType.new("s")
         )
-        action_sel_add.connect("activate", self._on_sel_add_to_playlist)
+        action_sel_add.connect(
+            "activate", lambda a, p: weak_self()._on_sel_add_to_playlist(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_sel_add)
         self.action_group.add_action(action_delete)
 
         action_save = Gio.SimpleAction.new("save_to_library", None)
-        action_save.connect("activate", self._on_save_to_library)
+        action_save.connect(
+            "activate", lambda a, p: weak_self()._on_save_to_library(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_save)
 
         action_unsave = Gio.SimpleAction.new("remove_from_library", None)
-        action_unsave.connect("activate", self._on_remove_from_library)
+        action_unsave.connect(
+            "activate", lambda a, p: weak_self()._on_remove_from_library(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_unsave)
 
         action_dl_all = Gio.SimpleAction.new("download_all", None)
-        action_dl_all.connect("activate", self._on_download_all)
+        action_dl_all.connect(
+            "activate", lambda a, p: weak_self()._on_download_all(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_dl_all)
 
         action_start_radio = Gio.SimpleAction.new("start_radio", None)
-        action_start_radio.connect("activate", self._on_start_radio)
+        action_start_radio.connect(
+            "activate", lambda a, p: weak_self()._on_start_radio(a, p) if weak_self() else None
+        )
         self.action_group.add_action(action_start_radio)
 
         a_play_next = Gio.SimpleAction.new("play_all_next", None)
-        a_play_next.connect("activate", self._on_play_all_next)
+        a_play_next.connect(
+            "activate", lambda a, p: weak_self()._on_play_all_next(a, p) if weak_self() else None
+        )
         self.action_group.add_action(a_play_next)
 
         a_add_queue = Gio.SimpleAction.new("add_all_to_queue", None)
-        a_add_queue.connect("activate", self._on_add_all_to_queue)
+        a_add_queue.connect(
+            "activate", lambda a, p: weak_self()._on_add_all_to_queue(a, p) if weak_self() else None
+        )
         self.action_group.add_action(a_add_queue)
 
         self._is_saved_to_library = False
@@ -256,7 +298,9 @@ class PlaylistPage(Adw.Bin):
         self.sort_dropdown.set_valign(Gtk.Align.CENTER)
         self.sort_dropdown.add_css_class("pill")
         self.sort_dropdown.add_css_class("sort-dropdown")
-        self.sort_dropdown.connect("notify::selected", self.on_sort_changed)
+        self.sort_dropdown.connect(
+            "notify::selected", lambda dd, spec: weak_self().on_sort_changed(dd, spec) if weak_self() else None
+        )
 
         self.details_col.append(actions_box)
         self.header_info_box.append(self.details_col)
@@ -267,7 +311,9 @@ class PlaylistPage(Adw.Bin):
         self.sort_dir_btn.add_css_class("flat")
         self.sort_dir_btn.add_css_class("circular")
         self.sort_dir_btn.set_tooltip_text("Toggle sort direction")
-        self.sort_dir_btn.connect("clicked", self._on_sort_dir_clicked)
+        self.sort_dir_btn.connect(
+            "clicked", lambda btn: weak_self()._on_sort_dir_clicked(btn) if weak_self() else None
+        )
 
         self.sort_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         self.sort_row.set_margin_top(12)
@@ -279,7 +325,9 @@ class PlaylistPage(Adw.Bin):
         self.select_btn.add_css_class("flat")
         self.select_btn.add_css_class("circular")
         self.select_btn.set_tooltip_text("Select multiple songs")
-        self.select_btn.connect("toggled", self._on_select_toggled)
+        self.select_btn.connect(
+            "toggled", lambda btn: weak_self()._on_select_toggled(btn) if weak_self() else None
+        )
 
         spacer = Gtk.Box()
         spacer.set_hexpand(True)
@@ -315,20 +363,26 @@ class PlaylistPage(Adw.Bin):
         sel_play_btn = Gtk.Button(icon_name="media-playback-start-symbolic")
         sel_play_btn.add_css_class("flat")
         sel_play_btn.set_tooltip_text("Play selected")
-        sel_play_btn.connect("clicked", self._on_sel_play)
+        sel_play_btn.connect(
+            "clicked", lambda btn: weak_self()._on_sel_play(btn) if weak_self() else None
+        )
         self.selection_bar.append(sel_play_btn)
 
         self.sel_add_btn = Gtk.Button(icon_name="list-add-symbolic")
         self.sel_add_btn.add_css_class("flat")
         self.sel_add_btn.set_tooltip_text("Add selected to playlist")
-        self.sel_add_btn.connect("clicked", self._on_sel_add_btn_clicked)
+        self.sel_add_btn.connect(
+            "clicked", lambda btn: weak_self()._on_sel_add_btn_clicked(btn) if weak_self() else None
+        )
         self.selection_bar.append(self.sel_add_btn)
 
         self.sel_remove_btn = Gtk.Button(icon_name="user-trash-symbolic")
         self.sel_remove_btn.add_css_class("flat")
         self.sel_remove_btn.add_css_class("destructive-action")
         self.sel_remove_btn.set_tooltip_text("Remove selected from playlist")
-        self.sel_remove_btn.connect("clicked", self._on_sel_remove)
+        self.sel_remove_btn.connect(
+            "clicked", lambda btn: weak_self()._on_sel_remove(btn) if weak_self() else None
+        )
         self.sel_remove_btn.set_visible(False)
         self.selection_bar.append(self.sel_remove_btn)
 
@@ -349,7 +403,9 @@ class PlaylistPage(Adw.Bin):
         sel_cancel_btn = Gtk.Button(icon_name="window-close-symbolic")
         sel_cancel_btn.add_css_class("flat")
         sel_cancel_btn.set_tooltip_text("Cancel selection")
-        sel_cancel_btn.connect("clicked", lambda b: self.select_btn.set_active(False))
+        sel_cancel_btn.connect(
+            "clicked", lambda b: weak_self().select_btn.set_active(False) if weak_self() else None
+        )
         self.selection_bar.append(sel_cancel_btn)
 
         self.header_container.append(self.selection_bar)
@@ -384,23 +440,35 @@ class PlaylistPage(Adw.Bin):
 
         # ── 3. List & ScrolledWindow ──────────────────────────────────────────
         factory = Gtk.SignalListItemFactory()
-        factory.connect("setup", self._setup_list_item)
-        factory.connect("bind", self._bind_list_item)
-        factory.connect("unbind", self._unbind_list_item)
-        factory.connect("teardown", self._teardown_list_item)
+        factory.connect(
+            "setup", lambda f, li: weak_self()._setup_list_item(f, li) if weak_self() else None
+        )
+        factory.connect(
+            "bind", lambda f, li: weak_self()._bind_list_item(f, li) if weak_self() else None
+        )
+        factory.connect(
+            "unbind", lambda f, li: weak_self()._unbind_list_item(f, li) if weak_self() else None
+        )
+        factory.connect(
+            "teardown", lambda f, li: weak_self()._teardown_list_item(f, li) if weak_self() else None
+        )
 
         self.songs_list = Gtk.ListView.new(self.selection_model, factory)
         self.songs_list.add_css_class("playlist-view")
         # Keyboard activation: Enter/Space on the focused row plays it. Mouse
         # clicks go through the per-row gesture (see _setup_list_item); the
         # ListView "activate" signal covers keyboard (and double-click).
-        self.songs_list.connect("activate", self._on_list_activate)
+        self.songs_list.connect(
+            "activate", lambda lv, pos: weak_self()._on_list_activate(lv, pos) if weak_self() else None
+        )
 
         scrolled = ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
         self.vadjust = scrolled.get_vadjustment()
-        self.vadjust.connect("value-changed", self._on_scroll)
+        self._scroll_handler_id = self.vadjust.connect(
+            "value-changed", lambda adj: weak_self()._on_scroll(adj) if weak_self() else None
+        )
 
         clamp = (
             Adw.ClampScrollable() if hasattr(Adw, "ClampScrollable") else Adw.Clamp()
@@ -540,22 +608,31 @@ class PlaylistPage(Adw.Bin):
 
         gesture = Gtk.GestureClick()
         gesture.set_button(3)
-        gesture.connect("released", self._on_row_right_click_gesture)
+        gesture.connect(
+            "released", lambda g, n, x, y: weak_self()._on_row_right_click_gesture(g, n, x, y) if weak_self() else None
+        )
         row.add_controller(gesture)
 
         # Long Press for touch
         lp = Gtk.GestureLongPress()
         lp.connect(
-            "pressed", lambda g, x, y: self._on_row_right_click_gesture(g, 1, x, y)
+            "pressed", lambda g, x, y: weak_self()._on_row_right_click_gesture(g, 1, x, y) if weak_self() else None
         )
         row.add_controller(lp)
 
         # Left Click Gesture instead of list_view activate
         left_click = Gtk.GestureClick()
         left_click.set_button(1)
-        left_click.connect("pressed", self._on_row_left_pressed, row)
-        left_click.connect("released", self._on_row_left_click, list_item)
+        weak_self = weakref.ref(self)
+        left_click.connect(
+            "pressed", lambda g, n, x, y, : weak_self()._on_row_left_pressed(g, n, x, y, g.get_widget()) if weak_self() and g.get_widget() is not None else None
+        )
+        left_click.connect(
+            "released", lambda g, n, x, y, li=list_item: weak_self()._on_row_left_click(g, n, x, y, li) if weak_self() else None
+        )
         row.add_controller(left_click)
+
+        row._lv_list_item_ref = weakref.ref(list_item)
 
         row._lv_video_data = None
         row._lv_full_track = None
@@ -641,7 +718,7 @@ class PlaylistPage(Adw.Bin):
             check.set_active(is_selected)
             row._lv_check_handler = check.connect(
                 "toggled",
-                lambda cb, vid=video_id, r=row: self._toggle_track_selection(vid, r),
+                lambda cb, vid=video_id, : self._toggle_track_selection(vid, g.get_widget()),
             )
         elif row._lv_check is not None:
             row._lv_check.set_visible(False)
@@ -772,11 +849,15 @@ class PlaylistPage(Adw.Bin):
             row.remove_css_class("playing")
 
         # Connect to player metadata changes
-        def on_meta_changed(player, *args, _row=row, _vid=video_id):
+        weak_row = weakref.ref(row)
+        def on_meta_changed(player, *args, _vid=video_id):
+            r = weak_row()
+            if not r:
+                return
             if bool(_vid and _vid == player.current_video_id):
-                _row.add_css_class("playing")
+                r.add_css_class("playing")
             else:
-                _row.remove_css_class("playing")
+                r.remove_css_class("playing")
 
         if getattr(row, "_lv_player_handler", None):
             self.player.disconnect(row._lv_player_handler)
@@ -1032,6 +1113,8 @@ class PlaylistPage(Adw.Bin):
         full population (update_ui's non-append branch, reorder_playlist).
         Do NOT mix with other code that splices in parallel — the tail
         splices use `track_store.get_n_items()` and will race."""
+        if getattr(self, "_cleaned_up", False):
+            return
         self._clear_track_store()
         if not tracks:
             return
@@ -1042,6 +1125,8 @@ class PlaylistPage(Adw.Bin):
             return
 
         def pump(cursor):
+            if getattr(self, "_cleaned_up", False):
+                return False
             if token != self._track_populate_token:
                 return False  # superseded
             end = min(cursor + batch, len(tracks))
@@ -1135,8 +1220,12 @@ class PlaylistPage(Adw.Bin):
         self._refresh_more_menu()
         # Connect download signals for live indicator updates
         dm = self.player.download_manager
-        self._dl_queued_id = dm.connect("item-queued", self._on_dl_indicator_update)
-        self._dl_done_id = dm.connect("item-done", self._on_dl_item_done)
+        self._dl_queued_id = dm.connect(
+            "item-queued", lambda dm, *args: weak_self()._on_dl_indicator_update(dm, *args) if weak_self() else None
+        )
+        self._dl_done_id = dm.connect(
+            "item-done", lambda dm, *args: weak_self()._on_dl_item_done(dm, *args) if weak_self() else None
+        )
 
     def _refresh_more_menu(self, is_owned=False):
         """Mark the more-menu as needing a rebuild; defer the actual work
@@ -1376,13 +1465,100 @@ class PlaylistPage(Adw.Bin):
     def _on_unmap(self, widget):
         self.emit("header-title-changed", "")
         # Disconnect download signals
+        if not hasattr(self, 'player') or self.player is None:
+            return
         dm = self.player.download_manager
         if hasattr(self, "_dl_queued_id") and self._dl_queued_id:
-            dm.disconnect(self._dl_queued_id)
+            try:
+                dm.disconnect(self._dl_queued_id)
+            except Exception:
+                pass
             self._dl_queued_id = None
         if hasattr(self, "_dl_done_id") and self._dl_done_id:
-            dm.disconnect(self._dl_done_id)
+            try:
+                dm.disconnect(self._dl_done_id)
+            except Exception:
+                pass
             self._dl_done_id = None
+
+    def _on_page_destroy(self, widget):
+        self.cleanup()
+
+    def cleanup(self):
+        """Perform resource cleanup when the page is popped/destroyed."""
+        self._cleaned_up = True
+
+        # Disconnect scroll handler
+        if getattr(self, "_scroll_handler_id", None) is not None:
+            if hasattr(self, "vadjust") and self.vadjust:
+                try:
+                    self.vadjust.disconnect(self._scroll_handler_id)
+                except Exception:
+                    pass
+            self._scroll_handler_id = None
+
+        # Disconnect download signals
+        dm = self.player.download_manager
+        if hasattr(self, "_dl_queued_id") and self._dl_queued_id:
+            try:
+                dm.disconnect(self._dl_queued_id)
+            except Exception:
+                pass
+            self._dl_queued_id = None
+        if hasattr(self, "_dl_done_id") and self._dl_done_id:
+            try:
+                dm.disconnect(self._dl_done_id)
+            except Exception:
+                pass
+            self._dl_done_id = None
+
+        # Clear track store
+        if hasattr(self, "track_store") and self.track_store:
+            try:
+                self.track_store.remove_all()
+            except Exception:
+                pass
+
+        self.current_tracks = []
+        self.original_tracks = []
+
+        # Recursively cleanup image widgets to cancel pending async loads
+        from ui.utils import cleanup_widget_images
+        cleanup_widget_images(self)
+
+        # Clear references to break reference cycles
+        self.player = None
+        self.client = None
+        self.header_container = None
+        self.header_info_box = None
+        self.cover_img = None
+        self.cover_wrapper = None
+        self.details_col = None
+        self.playlist_name_label = None
+        self.description_label = None
+        self.read_more_btn = None
+        self.desc_box = None
+        self.meta_label = None
+        self.stats_label = None
+        self.actions_box = None
+        self.more_btn = None
+        self.more_menu = None
+        self.sort_row = None
+        self.sort_dropdown = None
+        self.sort_dir_btn = None
+        self.select_btn = None
+        self.selection_bar = None
+        self.selection_label = None
+        self.sel_add_btn = None
+        self.sel_remove_btn = None
+        self.songs_list = None
+        self.vadjust = None
+        self.content_spinner = None
+        self.load_more_spinner = None
+        self.stack = None
+        self.main_box = None
+        self.selection_model = None
+        self.track_store = None
 
     # ── Load playlist ─────────────────────────────────────────────────────────
 
@@ -1477,7 +1653,9 @@ class PlaylistPage(Adw.Bin):
 
     def _schedule_details_fetch(self, playlist_id, delay=False):
         def start():
-            if self.playlist_id != playlist_id:
+            if getattr(self, "playlist_id", None) != playlist_id:
+                return False
+            if not getattr(self, "content_spinner", None):
                 return False
             self.content_spinner.set_visible(True)
             thread = threading.Thread(
@@ -1598,6 +1776,8 @@ class PlaylistPage(Adw.Bin):
     def _apply_disk_cache_header(self, token, payload):
         """Cheap header updates: title, description, meta strings, cover.
         Safe to run during the page-push animation."""
+        if getattr(self, "_cleaned_up", False):
+            return False
         if token != getattr(self, "_track_populate_token", 0):
             return False
         try:
@@ -1661,6 +1841,8 @@ class PlaylistPage(Adw.Bin):
         Worker has already done JSON parse + TrackItem construction; the
         main thread only owes the splice itself.
         """
+        if getattr(self, "_cleaned_up", False):
+            return False
         if token != getattr(self, "_track_populate_token", 0):
             return False
         try:
@@ -1710,6 +1892,8 @@ class PlaylistPage(Adw.Bin):
         # sees as a hard stutter right after the page opens. Splice in
         # smaller chunks with idle yields between so layout/paint can
         # interleave — total work is the same, but spread across frames.
+        if getattr(self, "_cleaned_up", False):
+            return False
         if token != getattr(self, "_track_populate_token", 0):
             return False
         try:
@@ -2307,6 +2491,8 @@ class PlaylistPage(Adw.Bin):
         total_tracks=None,
         is_owned=False,
     ):
+        if getattr(self, "_cleaned_up", False):
+            return
         self.stack.set_visible_child_name("content")
         self.content_spinner.set_visible(False)
 
@@ -2457,19 +2643,29 @@ class PlaylistPage(Adw.Bin):
     def _start_background_full_fetch(self):
         if getattr(self, "is_fully_fetched", False):
             return
+        if getattr(self, "_cleaned_up", False):
+            return
         print(f"Starting background fetch for full playlist: {self.playlist_id}")
 
+        client = self.client
+        pid = self.playlist_id
         def fetch_job():
+            if getattr(self, "_cleaned_up", False):
+                return
             try:
                 # get_playlist_full handles the full fetch and (via
                 # MusicClient.get_playlist_full) owns the disk-cache
                 # write once ytmusicapi / raw-continuation / yt_dlp have
                 # done their best. No cache logic here.
-                data = self.client.get_playlist_full(self.playlist_id, limit=None)
+                data = client.get_playlist_full(pid, limit=None)
+                if getattr(self, "_cleaned_up", False):
+                    return
                 tracks = data.get("tracks", []) if data else []
                 if tracks:
                     print(f"Background fetch complete. Fetched {len(tracks)} tracks.")
-                    self.client.set_cached_playlist_tracks(self.playlist_id, tracks)
+                    client.set_cached_playlist_tracks(pid, tracks)
+                    if getattr(self, "_cleaned_up", False):
+                        return
                     GObject.idle_add(self._on_background_fetch_complete, tracks)
             except Exception as e:
                 print(f"Error in background fetch: {e}")
@@ -2481,6 +2677,8 @@ class PlaylistPage(Adw.Bin):
         thread.start()
 
     def _on_background_fetch_complete(self, tracks=None):
+        if getattr(self, "_cleaned_up", False):
+            return
         if tracks is not None:
             self.original_tracks = tracks
         self.is_fully_fetched = True
@@ -2659,7 +2857,7 @@ class PlaylistPage(Adw.Bin):
             if vid:
                 row._lv_check_handler = check.connect(
                     "toggled",
-                    lambda cb, v=vid, r=row: self._toggle_track_selection(v, r),
+                    lambda cb, v=vid, : self._toggle_track_selection(v, g.get_widget()),
                 )
 
     def _refresh_all_row_visuals(self):
@@ -3261,7 +3459,7 @@ class PlaylistPage(Adw.Bin):
             a_toggle = Gio.SimpleAction.new("toggle_sel", None)
             a_toggle.connect(
                 "activate",
-                lambda act, p, v=vid, r=row: self._toggle_track_selection(v, r),
+                lambda act, p, v=vid, : self._toggle_track_selection(v, g.get_widget()),
             )
             group.add_action(a_toggle)
 
@@ -3495,6 +3693,8 @@ class PlaylistPage(Adw.Bin):
         self.load_playlist(pid)
 
     def _reshow_virtual(self, title, tracks, meta1):
+        if getattr(self, "_cleaned_up", False):
+            return
         self.original_tracks = tracks
         self.current_tracks = tracks
         total_seconds = sum(t.get("duration_seconds", 0) or 0 for t in tracks)

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -2906,14 +2906,16 @@ class PlaylistPage(Adw.Bin):
         from ui.widgets.add_to_playlist import mark_playlist_used
         mark_playlist_used(target_pid)
 
+        weak_self = weakref.ref(self)
+        client = self.client
         def thread_func():
-            success = self.client.add_playlist_items(target_pid, video_ids)
+            success = client.add_playlist_items(target_pid, video_ids)
             msg = (
                 f"Added {len(video_ids)} tracks to playlist"
                 if success
                 else "Failed to add tracks"
             )
-            GLib.idle_add(self._show_toast, msg)
+            GLib.idle_add(lambda: weak_self()._show_toast(msg) if weak_self() else None)
 
         threading.Thread(target=thread_func, daemon=True).start()
 
@@ -3210,12 +3212,13 @@ class PlaylistPage(Adw.Bin):
                 # The OMV→ATV swap is handled inside add_playlist_items;
                 # it auto-enables for single-item adds (this is the
                 # right-click case) and stays off for bulk.
+                weak_self = weakref.ref(self)
+                client = self.client
                 threading.Thread(
                     target=lambda: (
-                        self.client.add_playlist_items(target_pid, vids),
+                        client.add_playlist_items(target_pid, vids),
                         GLib.idle_add(
-                            self._show_toast,
-                            f"Added {n} track{'s' if n > 1 else ''} to playlist",
+                            lambda: weak_self()._show_toast(f"Added {n} track{'s' if n > 1 else ''} to playlist") if weak_self() else None
                         ),
                     ),
                     daemon=True,

--- a/src/ui/pages/search.py
+++ b/src/ui/pages/search.py
@@ -1,3 +1,4 @@
+import weakref
 from gi.repository import Gtk, Adw, GObject, GLib, Pango, Gio, Gdk
 import threading
 from api.client import MusicClient
@@ -893,6 +894,7 @@ class SearchPage(Adw.Bin):
                 )
                 like_btn.set_valign(Gtk.Align.CENTER)
                 box.append(like_btn)
+                row._like_btn = like_btn
 
             row.item_data = item
             row.set_activatable(True)
@@ -906,7 +908,7 @@ class SearchPage(Adw.Bin):
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, r=row: self.on_row_right_click(g, 1, x, y, r)
+                "pressed", lambda g, x, y, : self.on_row_right_click(g, 1, x, y, g.get_widget())
             )
             row.add_controller(lp)
 
@@ -1210,7 +1212,7 @@ class SearchPage(Adw.Bin):
             elif "browseId" in data:
                 # Check if it's a playlist or artist
                 if res_type in ["playlist", "album"] or data["browseId"].startswith(
-                    ("VL", "PL", "RD", "OL", "MPRE")
+                    ("VL", "PL", "RD", "OL", "MPRE", "FEmusic_release_")
                 ):
                     open_pid(data["browseId"])
                 else:

--- a/src/ui/pages/search.py
+++ b/src/ui/pages/search.py
@@ -389,7 +389,8 @@ class SearchPage(Adw.Bin):
             view_all_btn = Gtk.Button(label="View All")
             view_all_btn.add_css_class("pill")
             view_all_btn.add_css_class("flat")
-            view_all_btn.connect("clicked", lambda b, i=items, t=title: self.on_view_all_clicked(i, t))
+            weak_self = weakref.ref(self)
+            view_all_btn.connect("clicked", lambda b, i=items, t=title, ws=weak_self: ws().on_view_all_clicked(i, t) if ws() else None)
             h_box.append(view_all_btn)
 
         scroll_box.set_content(h_box)
@@ -908,7 +909,7 @@ class SearchPage(Adw.Bin):
             # Long Press for touch
             lp = Gtk.GestureLongPress()
             lp.connect(
-                "pressed", lambda g, x, y, : self.on_row_right_click(g, 1, x, y, g.get_widget())
+                "pressed", lambda g, x, y, ws=weakref.ref(self): ws().on_row_right_click(g, 1, x, y, g.get_widget()) if ws() else None
             )
             row.add_controller(lp)
 
@@ -1418,7 +1419,7 @@ class SearchPage(Adw.Bin):
 
         # Start Radio
         action_radio = Gio.SimpleAction.new("start_radio", None)
-        action_radio.connect("activate", lambda a, p: self._on_radio_action(data))
+        action_radio.connect("activate", lambda a, p, ws=weakref.ref(self): ws()._on_radio_action(data) if ws() else None)
         group.add_action(action_radio)
 
         # Build Menu Model

--- a/src/ui/queue_panel.py
+++ b/src/ui/queue_panel.py
@@ -1,5 +1,6 @@
 import gi
 import threading
+import weakref
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -110,6 +111,15 @@ class QueueRowWidget(Gtk.Box):
         item.connect("notify::is-playing", self._on_item_property_changed)
         item.connect("notify::is-paused", self._on_item_property_changed)
         self._update_playing_ui()
+
+    def unbind(self):
+        if self.model_item:
+            try:
+                self.model_item.disconnect_by_func(self._on_item_property_changed)
+            except Exception:
+                pass
+            self.model_item = None
+        self.panel = None
 
     def _on_item_property_changed(self, item, pspec):
         self._update_playing_ui()
@@ -248,6 +258,7 @@ class QueuePanel(Gtk.Box):
         factory = Gtk.SignalListItemFactory()
         factory.connect("setup", self._on_factory_setup)
         factory.connect("bind", self._on_factory_bind)
+        factory.connect("unbind", self._on_factory_unbind)
 
         self.list_view = Gtk.ListView(model=self.selection_model, factory=factory)
 
@@ -257,8 +268,14 @@ class QueuePanel(Gtk.Box):
         self.append(scrolled)
 
         # Signals
-        self.player.connect("state-changed", self._on_player_update)
-        self.player.connect("metadata-changed", self._on_player_update)
+        weak_self = weakref.ref(self)
+        self._player_state_handler = self.player.connect(
+            "state-changed", lambda player, *args: weak_self()._on_player_update(player, *args) if weak_self() else None
+        )
+        self._player_metadata_handler = self.player.connect(
+            "metadata-changed", lambda player, *args: weak_self()._on_player_update(player, *args) if weak_self() else None
+        )
+        self.connect("destroy", lambda w: weak_self()._on_destroy(w) if weak_self() else None)
         self.connect("map", self._on_map)  # Refresh when visible
 
         # Initial Populate
@@ -300,14 +317,16 @@ class QueuePanel(Gtk.Box):
         from ui.widgets.add_to_playlist import mark_playlist_used
         mark_playlist_used(playlist_id)
 
+        weak_self = weakref.ref(self)
+        client = self.player.client
         def thread_func():
-            success = self.player.client.add_playlist_items(playlist_id, video_ids)
+            success = client.add_playlist_items(playlist_id, video_ids)
             if success:
                 msg = f"Added {len(video_ids)} tracks to playlist"
                 print(msg)
-                GLib.idle_add(self._show_toast, msg)
+                GLib.idle_add(lambda: weak_self()._show_toast(msg) if weak_self() else None)
             else:
-                GLib.idle_add(self._show_toast, "Failed to add tracks")
+                GLib.idle_add(lambda: weak_self()._show_toast("Failed to add tracks") if weak_self() else None)
 
         threading.Thread(target=thread_func, daemon=True).start()
 
@@ -408,6 +427,25 @@ class QueuePanel(Gtk.Box):
         item = list_item.get_item()
         widget.bind(item, self)
 
+    def _on_factory_unbind(self, factory, list_item):
+        widget = list_item.get_child()
+        if widget and hasattr(widget, "unbind"):
+            widget.unbind()
+
+    def _on_destroy(self, widget):
+        if hasattr(self, "_player_state_handler") and self._player_state_handler is not None:
+            try:
+                self.player.disconnect(self._player_state_handler)
+            except Exception:
+                pass
+            self._player_state_handler = None
+        if hasattr(self, "_player_metadata_handler") and self._player_metadata_handler is not None:
+            try:
+                self.player.disconnect(self._player_metadata_handler)
+            except Exception:
+                pass
+            self._player_metadata_handler = None
+
     def _on_row_clicked(self, gesture, n_press, x, y, list_item):
         item = list_item.get_item()
         if item and item.index != self.player.current_queue_index:
@@ -453,21 +491,23 @@ class QueuePanel(Gtk.Box):
                     AddToPlaylistPopover, mark_playlist_used,
                 )
 
+                weak_self = weakref.ref(self)
                 def _on_select(target_pid):
                     if not target_pid:
                         return
                     mark_playlist_used(target_pid)
 
+                    client = self.player.client
                     def _thread():
                         # add_playlist_items auto-swaps OMV→ATV for
                         # single-item adds.
-                        success = self.player.client.add_playlist_items(
+                        success = client.add_playlist_items(
                             target_pid, [v]
                         )
                         if success:
-                            GLib.idle_add(self._show_toast, "Added to playlist")
+                            GLib.idle_add(lambda: weak_self()._show_toast("Added to playlist") if weak_self() else None)
                         else:
-                            GLib.idle_add(self._show_toast, "Failed to add")
+                            GLib.idle_add(lambda: weak_self()._show_toast("Failed to add") if weak_self() else None)
 
                     threading.Thread(target=_thread, daemon=True).start()
 

--- a/src/ui/utils.py
+++ b/src/ui/utils.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import weakref
 import time
 import urllib.request
 import collections
@@ -924,6 +925,18 @@ class AsyncImage(Gtk.Image):
             return
         submit_fetch(fn, *args)
 
+    def cancel_pending(self):
+        """Cancel any pending mapped fetch and clear references."""
+        self._pending_fetch = None
+        if getattr(self, "_map_handler_id", None):
+            try:
+                self.disconnect(self._map_handler_id)
+            except Exception:
+                pass
+            self._map_handler_id = None
+        self.set_from_paintable(None)
+        self.player = None
+
     def load_url(self, url, **kwargs):
         orig_url = url
         url = get_high_res_url(url, self.target_w)
@@ -1266,6 +1279,18 @@ class AsyncPicture(Gtk.Picture):
             return
         submit_fetch(fn, *args)
 
+    def cancel_pending(self):
+        """Cancel any pending mapped fetch and clear references."""
+        self._pending_fetch = None
+        if getattr(self, "_map_handler_id", None):
+            try:
+                self.disconnect(self._map_handler_id)
+            except Exception:
+                pass
+            self._map_handler_id = None
+        self.set_paintable(None)
+        self.player = None
+
     def load_url(self, url, **kwargs):
         orig_url = url
         url = get_high_res_url(url, self.target_size)
@@ -1431,6 +1456,18 @@ class AsyncPicture(Gtk.Picture):
                 self.player.update_track_thumbnail(video_id, url)
 
 
+def cleanup_widget_images(widget):
+    """Recursively cancel pending image fetches in a widget tree."""
+    if not widget:
+        return
+    if isinstance(widget, (AsyncImage, AsyncPicture)):
+        widget.cancel_pending()
+    child = widget.get_first_child() if hasattr(widget, 'get_first_child') else None
+    while child:
+        cleanup_widget_images(child)
+        child = child.get_next_sibling()
+
+
 class MarqueeLabel(Gtk.ScrolledWindow):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -1521,7 +1558,8 @@ class LikeButton(Gtk.Button):
         self.set_valign(Gtk.Align.CENTER)
 
         self.update_icon()
-        self.connect("clicked", self.on_clicked)
+        weak_self = weakref.ref(self)
+        self.connect("clicked", lambda btn: weak_self().on_clicked(btn) if weak_self() else None)
 
     def update_icon(self):
         if self.status == "LIKE":

--- a/src/ui/utils.py
+++ b/src/ui/utils.py
@@ -925,17 +925,7 @@ class AsyncImage(Gtk.Image):
             return
         submit_fetch(fn, *args)
 
-    def cancel_pending(self):
-        """Cancel any pending mapped fetch and clear references."""
-        self._pending_fetch = None
-        if getattr(self, "_map_handler_id", None):
-            try:
-                self.disconnect(self._map_handler_id)
-            except Exception:
-                pass
-            self._map_handler_id = None
-        self.set_from_paintable(None)
-        self.player = None
+
 
     def load_url(self, url, **kwargs):
         orig_url = url
@@ -1279,17 +1269,7 @@ class AsyncPicture(Gtk.Picture):
             return
         submit_fetch(fn, *args)
 
-    def cancel_pending(self):
-        """Cancel any pending mapped fetch and clear references."""
-        self._pending_fetch = None
-        if getattr(self, "_map_handler_id", None):
-            try:
-                self.disconnect(self._map_handler_id)
-            except Exception:
-                pass
-            self._map_handler_id = None
-        self.set_paintable(None)
-        self.player = None
+
 
     def load_url(self, url, **kwargs):
         orig_url = url
@@ -1456,16 +1436,7 @@ class AsyncPicture(Gtk.Picture):
                 self.player.update_track_thumbnail(video_id, url)
 
 
-def cleanup_widget_images(widget):
-    """Recursively cancel pending image fetches in a widget tree."""
-    if not widget:
-        return
-    if isinstance(widget, (AsyncImage, AsyncPicture)):
-        widget.cancel_pending()
-    child = widget.get_first_child() if hasattr(widget, 'get_first_child') else None
-    while child:
-        cleanup_widget_images(child)
-        child = child.get_next_sibling()
+
 
 
 class MarqueeLabel(Gtk.ScrolledWindow):

--- a/src/ui/widgets/song_row.py
+++ b/src/ui/widgets/song_row.py
@@ -1,4 +1,5 @@
 import gi
+import weakref
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -34,9 +35,16 @@ class SongRowWidget(Gtk.Box):
         # Keep the downloaded indicator in sync across any view showing this
         # song — react to both completions and removals from elsewhere in the UI.
         dm = self.player.download_manager
-        self._dm_done_handler = dm.connect("item-done", self._on_dm_item_done)
-        self._dm_removed_handler = dm.connect("download-removed", self._on_dm_download_removed)
-        self.connect("destroy", self._on_destroy)
+        weak_self = weakref.ref(self)
+        self._dm_done_handler = dm.connect(
+            "item-done", lambda dm, *args: weak_self()._on_dm_item_done(dm, *args) if weak_self() else None
+        )
+        self._dm_removed_handler = dm.connect(
+            "download-removed", lambda dm, *args: weak_self()._on_dm_download_removed(dm, *args) if weak_self() else None
+        )
+        self.connect(
+            "destroy", lambda w: weak_self()._on_destroy(w) if weak_self() else None
+        )
 
         self.row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         self.row.set_hexpand(True)
@@ -158,19 +166,28 @@ class SongRowWidget(Gtk.Box):
         # Gesture for Right Click (Context Menu)
         gesture = Gtk.GestureClick()
         gesture.set_button(3)  # Right click
-        gesture.connect("released", self.on_right_click)
+        weak_self = weakref.ref(self)
+        gesture.connect(
+            "released", lambda g, n, x, y: weak_self().on_right_click(g, n, x, y) if weak_self() else None
+        )
         self.row.add_controller(gesture)
 
         # Long Press for touch
         lp = Gtk.GestureLongPress()
-        lp.connect("pressed", lambda g, x, y: self.on_right_click(g, 1, x, y))
+        lp.connect(
+            "pressed", lambda g, x, y: weak_self().on_right_click(g, 1, x, y) if weak_self() else None
+        )
         self.row.add_controller(lp)
 
         # Gesture for Left Click (Activation)
         left_click = Gtk.GestureClick()
         left_click.set_button(1)
-        left_click.connect("pressed", self._on_left_pressed)
-        left_click.connect("released", self._on_left_released)
+        left_click.connect(
+            "pressed", lambda g, n, x, y: weak_self()._on_left_pressed(g, n, x, y) if weak_self() else None
+        )
+        left_click.connect(
+            "released", lambda g, n, x, y: weak_self()._on_left_released(g, n, x, y) if weak_self() else None
+        )
         self.row.add_controller(left_click)
 
     def _current_video_id(self):
@@ -261,8 +278,9 @@ class SongRowWidget(Gtk.Box):
         )
 
         # Connect directly to the player metadata signal (reliable than GObject property notify)
+        weak_self = weakref.ref(self)
         self._player_handler_id = self.player.connect(
-            "metadata-changed", self._on_player_metadata_changed
+            "metadata-changed", lambda player, *args: weak_self()._on_player_metadata_changed(player, *args) if weak_self() else None
         )
 
     def _on_player_metadata_changed(self, player, *args):
@@ -306,6 +324,8 @@ class SongRowWidget(Gtk.Box):
                 self.img._is_placeholder = True
         except Exception:
             pass
+        self.page = None
+        self.model_item = None
 
     def _apply_playing_state(self, is_playing):
         if is_playing:

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -255,6 +255,9 @@ class MainWindow(Adw.ApplicationWindow):
         ctrl.connect("key-pressed", self.on_window_key_pressed)
         self.add_controller(ctrl)
 
+        # Setup periodic garbage collection to free C-level objects (GdkTexture, GdkPixbuf, Widgets)
+        GLib.timeout_add(5000, self._run_periodic_gc)
+
         # Avatar menu button — replaces the hamburger. Opens a popover
         # with the user's profile, their channel link, the library
         # navigation shortcuts (upload/history/downloads), and the
@@ -1419,6 +1422,9 @@ class MainWindow(Adw.ApplicationWindow):
             page.load()
 
         nav_page.connect("shown", _on_shown)
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(page)
         nav.push(nav_page)
 
     def _open_downloads_from_menu(self):
@@ -1441,6 +1447,9 @@ class MainWindow(Adw.ApplicationWindow):
             threading.Thread(target=_fetch, daemon=True).start()
 
         nav_page.connect("shown", _on_shown)
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(page)
         nav.push(nav_page)
         page.stack.set_visible_child_name("loading")
 
@@ -2475,6 +2484,7 @@ class MainWindow(Adw.ApplicationWindow):
 
             # Connect to page changes to update Back Button
             nav_view.connect("notify::visible-page", self.update_back_button_visibility)
+            nav_view.connect("popped", self._on_nav_page_popped)
 
             def on_push(nav_view):
                 def tag_match(page_a, page_b) -> bool:
@@ -2542,6 +2552,29 @@ class MainWindow(Adw.ApplicationWindow):
 
     def set_header_title(self, title):
         pass
+
+    def _on_nav_page_popped(self, nav_view, nav_page):
+        """Clean up a page after it's been popped from a NavigationView."""
+        child = nav_page.get_child()
+        if child:
+            if hasattr(self, '_alive_pages') and child in self._alive_pages:
+                self._alive_pages.remove(child)
+            if hasattr(child, 'cleanup'):
+                try:
+                    child.cleanup()
+                except Exception as e:
+                    print(f"Error during page cleanup: {e}")
+            try:
+                nav_page.set_child(None)
+            except Exception:
+                pass
+        import gc
+        gc.collect()
+
+    def _run_periodic_gc(self):
+        import gc
+        gc.collect()
+        return True
 
     def _get_page_content(self, tab_name):
         # Helper to traverse: NavView -> NavPage -> ToolbarView -> Content
@@ -2710,6 +2743,9 @@ class MainWindow(Adw.ApplicationWindow):
         nav_page.connect("shown", _on_shown)
 
         # Push to stack
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(playlist_page)
         active_nav.push(nav_page)
 
         # Connect title change signal
@@ -2767,6 +2803,9 @@ class MainWindow(Adw.ApplicationWindow):
             child=artist_page, title=initial_name if initial_name else f"Artist_{channel_id}"
         )
 
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(artist_page)
         active_nav.push(nav_page)
 
         artist_page.load_artist(channel_id, initial_name)
@@ -2796,6 +2835,9 @@ class MainWindow(Adw.ApplicationWindow):
 
         nav_page = Adw.NavigationPage(child=disco_page, title=title)
 
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(disco_page)
         active_nav.push(nav_page)
 
         disco_page.load_discography(channel_id, title, browse_id, params, initial_items)
@@ -2816,6 +2858,9 @@ class MainWindow(Adw.ApplicationWindow):
 
         nav_page = Adw.NavigationPage(child=mood_page, title=title)
 
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(mood_page)
         active_nav.push(nav_page)
 
         mood_page.load_mood(params, title)
@@ -2841,6 +2886,9 @@ class MainWindow(Adw.ApplicationWindow):
             display_title = "All Moods & Moments"
 
         nav_page = Adw.NavigationPage(child=all_moods_page, title=display_title)
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(all_moods_page)
         active_nav.push(nav_page)
 
     def open_category(self, params, title):
@@ -2857,6 +2905,9 @@ class MainWindow(Adw.ApplicationWindow):
         cat_page.connect("header-title-changed", self.on_playlist_header_title_changed)
 
         nav_page = Adw.NavigationPage(child=cat_page, title=title)
+        if not hasattr(self, '_alive_pages'):
+            self._alive_pages = set()
+        self._alive_pages.add(cat_page)
         active_nav.push(nav_page)
 
         cat_page.load_category(params, title)
@@ -2972,8 +3023,15 @@ class MainWindow(Adw.ApplicationWindow):
                 from api.client import MusicClient
 
                 client = MusicClient()
-                playlist_id = client.api.get_album(album_id).get("audioPlaylistId")
-                GObject.idle_add(self.open_playlist, playlist_id, {"title": album_name})
+                try:
+                    playlist_id = client.api.get_album(album_id).get("audioPlaylistId")
+                    if playlist_id:
+                        GObject.idle_add(self.open_playlist, playlist_id, {"title": album_name})
+                    else:
+                        GObject.idle_add(self.open_playlist, album_id, {"title": album_name})
+                except Exception as e:
+                    print(f"Failed to resolve audioPlaylistId for {album_id}: {e}")
+                    GObject.idle_add(self.open_playlist, album_id, {"title": album_name})
             else:
                 # It's an implied playlist ID or similar
                 GObject.idle_add(self.open_playlist, album_id, {"title": album_name})

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -255,8 +255,6 @@ class MainWindow(Adw.ApplicationWindow):
         ctrl.connect("key-pressed", self.on_window_key_pressed)
         self.add_controller(ctrl)
 
-        # Setup periodic garbage collection to free C-level objects (GdkTexture, GdkPixbuf, Widgets)
-        GLib.timeout_add(5000, self._run_periodic_gc)
 
         # Avatar menu button — replaces the hamburger. Opens a popover
         # with the user's profile, their channel link, the library
@@ -1422,9 +1420,6 @@ class MainWindow(Adw.ApplicationWindow):
             page.load()
 
         nav_page.connect("shown", _on_shown)
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(page)
         nav.push(nav_page)
 
     def _open_downloads_from_menu(self):
@@ -1447,9 +1442,6 @@ class MainWindow(Adw.ApplicationWindow):
             threading.Thread(target=_fetch, daemon=True).start()
 
         nav_page.connect("shown", _on_shown)
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(page)
         nav.push(nav_page)
         page.stack.set_visible_child_name("loading")
 
@@ -2484,7 +2476,6 @@ class MainWindow(Adw.ApplicationWindow):
 
             # Connect to page changes to update Back Button
             nav_view.connect("notify::visible-page", self.update_back_button_visibility)
-            nav_view.connect("popped", self._on_nav_page_popped)
 
             def on_push(nav_view):
                 def tag_match(page_a, page_b) -> bool:
@@ -2553,28 +2544,6 @@ class MainWindow(Adw.ApplicationWindow):
     def set_header_title(self, title):
         pass
 
-    def _on_nav_page_popped(self, nav_view, nav_page):
-        """Clean up a page after it's been popped from a NavigationView."""
-        child = nav_page.get_child()
-        if child:
-            if hasattr(self, '_alive_pages') and child in self._alive_pages:
-                self._alive_pages.remove(child)
-            if hasattr(child, 'cleanup'):
-                try:
-                    child.cleanup()
-                except Exception as e:
-                    print(f"Error during page cleanup: {e}")
-            try:
-                nav_page.set_child(None)
-            except Exception:
-                pass
-        import gc
-        gc.collect()
-
-    def _run_periodic_gc(self):
-        import gc
-        gc.collect()
-        return True
 
     def _get_page_content(self, tab_name):
         # Helper to traverse: NavView -> NavPage -> ToolbarView -> Content
@@ -2743,9 +2712,6 @@ class MainWindow(Adw.ApplicationWindow):
         nav_page.connect("shown", _on_shown)
 
         # Push to stack
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(playlist_page)
         active_nav.push(nav_page)
 
         # Connect title change signal
@@ -2803,9 +2769,6 @@ class MainWindow(Adw.ApplicationWindow):
             child=artist_page, title=initial_name if initial_name else f"Artist_{channel_id}"
         )
 
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(artist_page)
         active_nav.push(nav_page)
 
         artist_page.load_artist(channel_id, initial_name)
@@ -2835,9 +2798,6 @@ class MainWindow(Adw.ApplicationWindow):
 
         nav_page = Adw.NavigationPage(child=disco_page, title=title)
 
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(disco_page)
         active_nav.push(nav_page)
 
         disco_page.load_discography(channel_id, title, browse_id, params, initial_items)
@@ -2858,9 +2818,6 @@ class MainWindow(Adw.ApplicationWindow):
 
         nav_page = Adw.NavigationPage(child=mood_page, title=title)
 
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(mood_page)
         active_nav.push(nav_page)
 
         mood_page.load_mood(params, title)
@@ -2886,9 +2843,6 @@ class MainWindow(Adw.ApplicationWindow):
             display_title = "All Moods & Moments"
 
         nav_page = Adw.NavigationPage(child=all_moods_page, title=display_title)
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(all_moods_page)
         active_nav.push(nav_page)
 
     def open_category(self, params, title):
@@ -2905,9 +2859,6 @@ class MainWindow(Adw.ApplicationWindow):
         cat_page.connect("header-title-changed", self.on_playlist_header_title_changed)
 
         nav_page = Adw.NavigationPage(child=cat_page, title=title)
-        if not hasattr(self, '_alive_pages'):
-            self._alive_pages = set()
-        self._alive_pages.add(cat_page)
         active_nav.push(nav_page)
 
         cat_page.load_category(params, title)

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -2,6 +2,7 @@ import colorsys
 import os
 import sys
 import threading
+import weakref
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -1420,6 +1421,7 @@ class MainWindow(Adw.ApplicationWindow):
             page.load()
 
         nav_page.connect("shown", _on_shown)
+        self._register_alive_page(page)
         nav.push(nav_page)
 
     def _open_downloads_from_menu(self):
@@ -1442,6 +1444,7 @@ class MainWindow(Adw.ApplicationWindow):
             threading.Thread(target=_fetch, daemon=True).start()
 
         nav_page.connect("shown", _on_shown)
+        self._register_alive_page(page)
         nav.push(nav_page)
         page.stack.set_visible_child_name("loading")
 
@@ -2476,6 +2479,7 @@ class MainWindow(Adw.ApplicationWindow):
 
             # Connect to page changes to update Back Button
             nav_view.connect("notify::visible-page", self.update_back_button_visibility)
+            nav_view.connect("popped", self._on_nav_page_popped)
 
             def on_push(nav_view):
                 def tag_match(page_a, page_b) -> bool:
@@ -2544,6 +2548,28 @@ class MainWindow(Adw.ApplicationWindow):
     def set_header_title(self, title):
         pass
 
+    def _register_alive_page(self, page):
+        if not hasattr(self, "_alive_pages"):
+            self._alive_pages = set()
+        self._alive_pages.add(page)
+
+    def _on_nav_page_popped(self, nav_view, nav_page):
+        """Clean up a page after it's been popped from a NavigationView."""
+        child = nav_page.get_child()
+        if child:
+            if hasattr(self, '_alive_pages') and child in self._alive_pages:
+                self._alive_pages.remove(child)
+            if hasattr(child, 'cleanup'):
+                try:
+                    child.cleanup()
+                except Exception as e:
+                    print(f"Error during page cleanup: {e}")
+            try:
+                nav_page.set_child(None)
+            except Exception:
+                pass
+        import gc
+        gc.collect()
 
     def _get_page_content(self, tab_name):
         # Helper to traverse: NavView -> NavPage -> ToolbarView -> Content
@@ -2712,6 +2738,7 @@ class MainWindow(Adw.ApplicationWindow):
         nav_page.connect("shown", _on_shown)
 
         # Push to stack
+        self._register_alive_page(playlist_page)
         active_nav.push(nav_page)
 
         # Connect title change signal
@@ -2769,6 +2796,7 @@ class MainWindow(Adw.ApplicationWindow):
             child=artist_page, title=initial_name if initial_name else f"Artist_{channel_id}"
         )
 
+        self._register_alive_page(artist_page)
         active_nav.push(nav_page)
 
         artist_page.load_artist(channel_id, initial_name)
@@ -2798,6 +2826,7 @@ class MainWindow(Adw.ApplicationWindow):
 
         nav_page = Adw.NavigationPage(child=disco_page, title=title)
 
+        self._register_alive_page(disco_page)
         active_nav.push(nav_page)
 
         disco_page.load_discography(channel_id, title, browse_id, params, initial_items)
@@ -2818,6 +2847,7 @@ class MainWindow(Adw.ApplicationWindow):
 
         nav_page = Adw.NavigationPage(child=mood_page, title=title)
 
+        self._register_alive_page(mood_page)
         active_nav.push(nav_page)
 
         mood_page.load_mood(params, title)
@@ -2843,6 +2873,7 @@ class MainWindow(Adw.ApplicationWindow):
             display_title = "All Moods & Moments"
 
         nav_page = Adw.NavigationPage(child=all_moods_page, title=display_title)
+        self._register_alive_page(all_moods_page)
         active_nav.push(nav_page)
 
     def open_category(self, params, title):
@@ -2859,6 +2890,7 @@ class MainWindow(Adw.ApplicationWindow):
         cat_page.connect("header-title-changed", self.on_playlist_header_title_changed)
 
         nav_page = Adw.NavigationPage(child=cat_page, title=title)
+        self._register_alive_page(cat_page)
         active_nav.push(nav_page)
 
         cat_page.load_category(params, title)


### PR DESCRIPTION
This PR resolves significant memory leaks occurring during navigation by breaking circular references between Python objects and GTK widgets ([#63](https://github.com/m-obeid/Mixtapes/issues/63)). Previously, passing `self` and UI widgets into signal handlers (like lambdas or closures) created reference cycles. Because these cycles crossed the C-level (GTK) and Python boundary, the Python Garbage Collector was unable to free the pages when they were destroyed or removed from the view stack.

**What was done:**

* **Weak References (`weakref`):** Replaced strong `self` references with `weakref.ref(self)` in signal closures and lambdas across major UI pages to break the primary `Page -> Widget -> Lambda -> Page` memory cycles.
* **Breaking Widget-to-Gesture Cycles:** When connecting gestures (`Gtk.GestureClick`), passing the widget into the lambda as a default argument (e.g., `ib=item_box`) created a hard circular reference (`Widget -> Gesture -> Lambda -> Widget`). This was fixed by using `weakref.ref(item_box)`. 
* **Safe PyGObject Wrapper Preservation:** Because PyGObject aggressively garbage collects Python wrappers for generic widgets (like `Gtk.Box`) if there are no strong references in Python, simply using a weak reference caused click events to silently fail when the wrapper died prematurely. To fix this, we now store a strong reference to the widget inside a list on the parent Page object (`self._alive_grid_items.append(item_box)`). When the Page is closed, its internal list is destroyed, the wrappers lose their strong references, the weak references die safely, and GTK cleanly unloads the widget hierarchy.
* **Explicit Cleanup Methods:** Implemented explicit `cleanup()` and `_on_page_destroy()` methods to manually clear out lists (`self.items`, `self.current_tracks`), remove child widgets from their parents (e.g., `self.list_box.remove(child)`), and sever GObject reference cycles.
* **Signal Disconnection:** Stored handler IDs (such as `_scroll_handler_id` and `_player_metadata_handler`) so they can be explicitly disconnected during page cleanup.
* **Widget Image Cleanup:** Added calls to `cleanup_widget_images(self)` during the destroy phase to cancel any pending asynchronous image loads.

**Example/Impact:**
* **Before**
```
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 500, HistoryPage: 1, LikeButton: 412
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 634, HistoryPage: 2, LikeButton: 812
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 769, HistoryPage: 3, LikeButton: 1212
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 904, HistoryPage: 4, LikeButton: 1612
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 1039, HistoryPage: 5, LikeButton: 2012
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 1170, HistoryPage: 6, LikeButton: 2412
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 1301, HistoryPage: 7, LikeButton: 2812
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 1432, HistoryPage: 8, LikeButton: 3212
[DEBUG-GC] Alive pages/widgets: AsyncImage: 209, AsyncPicture: 1563, HistoryPage: 9, LikeButton: 3612
```

* **After**
```
[DEBUG-GC] Alive pages/widgets: AsyncImage: 187, AsyncPicture: 526, LikeButton: 217, PlaylistPage: 2
[DEBUG-GC] Alive pages/widgets: AsyncImage: 187, AsyncPicture: 726, HistoryPage: 1, LikeButton: 417, PlaylistPage: 2
[DEBUG-GC] Alive pages/widgets: AsyncImage: 187, AsyncPicture: 526, HistoryPage: 1, LikeButton: 217, PlaylistPage: 2
[DEBUG-GC] Alive pages/widgets: AsyncImage: 187, AsyncPicture: 726, HistoryPage: 2, LikeButton: 417, PlaylistPage: 2
[DEBUG-GC] Alive pages/widgets: AsyncImage: 187, AsyncPicture: 526, HistoryPage: 1, LikeButton: 217, PlaylistPage: 2
```