### PR TITLE
Add aggressive memory caps

### DIFF
--- a/src/ui/cover_effects.py
+++ b/src/ui/cover_effects.py
@@ -7,6 +7,8 @@ import io
 import os
 import re
 import threading
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 
 from gi.repository import GLib
 
@@ -17,8 +19,11 @@ from ui.utils import (
 )
 
 
-_blur_cache = {}    # url -> path to blurred PNG
-_color_cache = {}   # url -> (r, g, b) normalized 0..1
+MAX_BLUR_CACHE_ENTRIES = 48
+MAX_COLOR_CACHE_ENTRIES = 128
+_cache_lock = threading.Lock()
+_blur_cache = OrderedDict()    # cache key -> path to blurred PNG
+_color_cache = OrderedDict()   # url -> (r, g, b) normalized 0..1
 
 # Coalesce concurrent _ensure_image_bytes() calls for the same URL. On a
 # track change the blur + accent-color workers both run on their own
@@ -28,6 +33,46 @@ _color_cache = {}   # url -> (r, g, b) normalized 0..1
 # disk cache.
 _inflight_lock = threading.Lock()
 _inflight = {}  # url -> threading.Event
+_effect_executor = ThreadPoolExecutor(
+    max_workers=2,
+    thread_name_prefix="muse-cover-effects",
+)
+
+
+def _submit_effect_worker(fn):
+    _effect_executor.submit(fn)
+
+
+def _remember_blur_cache(cache_key, path):
+    with _cache_lock:
+        _blur_cache[cache_key] = path
+        _blur_cache.move_to_end(cache_key)
+        while len(_blur_cache) > MAX_BLUR_CACHE_ENTRIES:
+            _blur_cache.popitem(last=False)
+
+
+def _get_blur_cache(cache_key):
+    with _cache_lock:
+        path = _blur_cache.get(cache_key)
+        if path is not None:
+            _blur_cache.move_to_end(cache_key)
+        return path
+
+
+def _remember_color_cache(url, color):
+    with _cache_lock:
+        _color_cache[url] = color
+        _color_cache.move_to_end(url)
+        while len(_color_cache) > MAX_COLOR_CACHE_ENTRIES:
+            _color_cache.popitem(last=False)
+
+
+def _get_color_cache(url):
+    with _cache_lock:
+        color = _color_cache.get(url)
+        if color is not None:
+            _color_cache.move_to_end(url)
+        return color
 
 
 def _blur_cache_dir():
@@ -162,7 +207,7 @@ def get_blurred_cover(
         return
 
     cache_key = (url, blur_radius, output_size, tuple(tint))
-    cached_path = _blur_cache.get(cache_key)
+    cached_path = _get_blur_cache(cache_key)
     if cached_path and os.path.exists(cached_path):
         if callback:
             GLib.idle_add(callback, cached_path)
@@ -174,7 +219,7 @@ def get_blurred_cover(
         f"{_thumb_cache_key(url)}_b{blur_radius}_s{output_size}_{tint_tag}.png",
     )
     if os.path.exists(out_path):
-        _blur_cache[cache_key] = out_path
+        _remember_blur_cache(cache_key, out_path)
         if callback:
             GLib.idle_add(callback, out_path)
         return
@@ -211,7 +256,7 @@ def get_blurred_cover(
             tmp_path = out_path + ".tmp"
             img.save(tmp_path, "PNG", optimize=True)
             os.replace(tmp_path, out_path)
-            _blur_cache[cache_key] = out_path
+            _remember_blur_cache(cache_key, out_path)
             if callback:
                 GLib.idle_add(callback, out_path)
         except Exception as e:
@@ -219,7 +264,7 @@ def get_blurred_cover(
             if callback:
                 GLib.idle_add(callback, None)
 
-    threading.Thread(target=_worker, daemon=True).start()
+    _submit_effect_worker(_worker)
 
 
 # ─── Dominant color extraction ─────────────────────────────────────────────
@@ -242,7 +287,7 @@ def get_dominant_color(url, callback=None):
             GLib.idle_add(callback, None)
         return
 
-    cached = _color_cache.get(url)
+    cached = _get_color_cache(url)
     if cached is not None:
         if callback:
             GLib.idle_add(callback, cached)
@@ -291,7 +336,7 @@ def get_dominant_color(url, callback=None):
                 best = (r / 255.0, g / 255.0, b / 255.0)
 
             if best is not None:
-                _color_cache[url] = best
+                _remember_color_cache(url, best)
             if callback:
                 GLib.idle_add(callback, best)
         except Exception as e:
@@ -299,4 +344,4 @@ def get_dominant_color(url, callback=None):
             if callback:
                 GLib.idle_add(callback, None)
 
-    threading.Thread(target=_worker, daemon=True).start()
+    _submit_effect_worker(_worker)

--- a/src/ui/cover_effects.py
+++ b/src/ui/cover_effects.py
@@ -19,8 +19,8 @@ from ui.utils import (
 )
 
 
-MAX_BLUR_CACHE_ENTRIES = 48
-MAX_COLOR_CACHE_ENTRIES = 128
+MAX_BLUR_CACHE_ENTRIES = 16
+MAX_COLOR_CACHE_ENTRIES = 64
 _cache_lock = threading.Lock()
 _blur_cache = OrderedDict()    # cache key -> path to blurred PNG
 _color_cache = OrderedDict()   # url -> (r, g, b) normalized 0..1
@@ -187,7 +187,7 @@ def _ensure_image_bytes(url):
 def get_blurred_cover(
     url,
     blur_radius=42,
-    output_size=720,
+    output_size=512,
     tint=(0, 0, 0, 150),
     callback=None,
 ):

--- a/src/ui/expanded_player.py
+++ b/src/ui/expanded_player.py
@@ -5,6 +5,10 @@ from ui.queue_panel import QueuePanel
 from ui.widgets.lyrics_view import LyricsView
 
 
+MAX_CAROUSEL_COVERS = 31
+CAROUSEL_PRELOAD_RADIUS = 5
+
+
 class ExpandedPlayer(Gtk.Box):
     @GObject.Signal
     def dismiss(self):
@@ -58,6 +62,7 @@ class ExpandedPlayer(Gtk.Box):
         main_box.set_margin_bottom(16)
 
         self.covers = []
+        self._cover_offset = 0
         self.cover_img = self._make_cover()  # fallback center
 
         self.carousel = Adw.Carousel()
@@ -369,7 +374,8 @@ class ExpandedPlayer(Gtk.Box):
 
     def _center_carousel(self):
         self._ignore_page_change = True
-        self.carousel.scroll_to(self.cover_img, animate=False)
+        if self.cover_img and self.cover_img.get_parent() == self.carousel:
+            self.carousel.scroll_to(self.cover_img, animate=False)
         self._ignore_page_change = False
         return False
 
@@ -420,12 +426,21 @@ class ExpandedPlayer(Gtk.Box):
         return None
 
     def _sync_carousel_queue(self):
-        """Sync carousel sizing to match queue and lazy-load neighbors."""
+        """Keep a bounded carousel window around the current queue item."""
         queue_len = len(self.player.queue)
         idx = self.player.current_queue_index
 
         if queue_len == 0:
+            self._cover_offset = 0
+            while self.covers:
+                cover = self.covers.pop()
+                cover.video_id = None
+                cover.load_url(None)
+                if cover.get_parent() == self.carousel:
+                    self.carousel.remove(cover)
             return
+        if idx < 0 or idx >= queue_len:
+            idx = 0
 
         self._ignore_page_change = True
         # Re-armable token: only the most recent sync's timer is allowed to
@@ -436,91 +451,57 @@ class ExpandedPlayer(Gtk.Box):
         self._carousel_sync_token = getattr(self, "_carousel_sync_token", 0) + 1
         token = self._carousel_sync_token
 
-        # Trim excess covers immediately — removing widgets is cheap and we
-        # want the carousel page count tight before we scroll_to.
-        while len(self.covers) > queue_len:
+        window_len = min(queue_len, MAX_CAROUSEL_COVERS)
+        half_window = window_len // 2
+        max_offset = max(0, queue_len - window_len)
+        self._cover_offset = min(max(idx - half_window, 0), max_offset)
+
+        while len(self.covers) > window_len:
             cover = self.covers.pop()
+            cover.video_id = None
+            cover.load_url(None)
             if cover.get_parent() == self.carousel:
                 self.carousel.remove(cover)
 
-        # Adding new covers in bulk is the expensive part — _make_cover +
-        # carousel.append for an 850-track playlist measured at ~800ms of
-        # main-thread time, the exact "sometimes 800ms hang on click" the
-        # user reported. Front-load only what's needed for the current view
-        # (center ± a small buffer + the actively-playing index); idle-pump
-        # the rest in the background so the click handler returns fast.
-        needed_count = queue_len - len(self.covers)
-        if needed_count > 0:
-            BUFFER = 15
-            new_lo = max(len(self.covers), idx - BUFFER) if idx >= 0 else len(self.covers)
-            new_hi = min(queue_len, (idx + BUFFER + 1) if idx >= 0 else queue_len)
+        while len(self.covers) < window_len:
+            cover = self._make_cover()
+            self.covers.append(cover)
+            self.carousel.append(cover)
 
-            # Cover slots before/at/after the visible window are appended in
-            # carousel order, so we just iterate from current count up to
-            # queue_len. Synchronously create the priority window first, then
-            # idle-pump the rest.
-            priority_end = min(queue_len, max(new_hi, len(self.covers) + BUFFER))
-            while len(self.covers) < priority_end:
-                cover = self._make_cover()
-                self.covers.append(cover)
-                self.carousel.append(cover)
-
-            if len(self.covers) < queue_len:
-                # Pump the tail across idle ticks. Each chunk is small enough
-                # to fit comfortably in a single frame.
-                CHUNK = 40
-
-                def _pump_tail():
-                    if token != self._carousel_sync_token:
-                        return False  # superseded by a newer sync
-                    target_len = len(self.player.queue)
-                    end = min(len(self.covers) + CHUNK, target_len)
-                    while len(self.covers) < end:
-                        cover = self._make_cover()
-                        self.covers.append(cover)
-                        self.carousel.append(cover)
-                    if len(self.covers) < target_len:
-                        GLib.idle_add(_pump_tail, priority=GLib.PRIORITY_LOW)
-                    return False
-
-                GLib.idle_add(_pump_tail, priority=GLib.PRIORITY_LOW)
-
-        if 0 <= idx < len(self.covers):
-            self.cover_img = self.covers[idx]
+        page_idx = idx - self._cover_offset
+        if 0 <= page_idx < len(self.covers):
+            self.cover_img = self.covers[page_idx]
 
         self._last_lazy_idx = -1  # Force reload of the new window's covers
-        self._lazy_load_covers_around(idx)
+        self._lazy_load_covers_around(page_idx)
 
-        if 0 <= idx < len(self.covers):
-            self.carousel.scroll_to(self.covers[idx], animate=False)
+        if 0 <= page_idx < len(self.covers):
+            self.carousel.scroll_to(self.covers[page_idx], animate=False)
 
         GLib.timeout_add(200, self._allow_page_change, token)
 
-    def _lazy_load_covers_around(self, center_idx):
-        # Walking all N covers on every skip was O(queue length) per click —
-        # ~50-100ms of pure Python on a 850-track playlist, even though only
-        # ±5 covers actually need attention. Use a delta walk: update the
-        # 11 covers in the new window, clear the small set that just left it.
+    def _lazy_load_covers_around(self, center_page_idx):
         old_center = getattr(self, "_last_lazy_idx", -1)
-        if center_idx == old_center:
+        if center_page_idx == old_center:
             return
-        self._last_lazy_idx = center_idx
+        self._last_lazy_idx = center_page_idx
 
-        R = 5
+        R = CAROUSEL_PRELOAD_RADIUS
         total = len(self.covers)
         if total == 0:
             return
-        new_lo = max(0, center_idx - R)
-        new_hi = min(total - 1, center_idx + R)
+        new_lo = max(0, center_page_idx - R)
+        new_hi = min(total - 1, center_page_idx + R)
 
-        def _set_cover(i):
-            cover = self.covers[i]
-            thumb = self._get_track_thumb(i)
+        def _set_cover(page_idx):
+            cover = self.covers[page_idx]
+            queue_idx = self._cover_offset + page_idx
+            thumb = self._get_track_thumb(queue_idx)
             if thumb:
                 if not cover.get_visible():
                     cover.set_visible(True)
                 if cover.url != thumb:
-                    cover.video_id = self.player.queue[i].get("videoId")
+                    cover.video_id = self.player.queue[queue_idx].get("videoId")
                     cover.load_url(thumb)
             else:
                 if cover.get_visible():
@@ -529,8 +510,8 @@ class ExpandedPlayer(Gtk.Box):
                 if cover.url is not None:
                     cover.load_url(None)
 
-        def _clear_cover(i):
-            cover = self.covers[i]
+        def _clear_cover(page_idx):
+            cover = self.covers[page_idx]
             cover.video_id = None
             if cover.url is not None:
                 cover.load_url(None)
@@ -545,10 +526,10 @@ class ExpandedPlayer(Gtk.Box):
         if old_center >= 0:
             old_lo = max(0, old_center - R)
             old_hi = min(total - 1, old_center + R)
-            for i in range(old_lo, old_hi + 1):
-                if new_lo <= i <= new_hi:
+            for page_idx in range(old_lo, old_hi + 1):
+                if new_lo <= page_idx <= new_hi:
                     continue
-                _clear_cover(i)
+                _clear_cover(page_idx)
 
     def _allow_page_change(self, token=None):
         # Only the latest sync's timer may clear the flag.
@@ -821,27 +802,28 @@ class ExpandedPlayer(Gtk.Box):
             return
 
         pos = carousel.get_position()
-        idx = int(round(pos))
+        page_idx = int(round(pos))
 
         # Dynamically load array ranges during scroll
-        if 0 <= idx < len(self.covers):
-            self._lazy_load_covers_around(idx)
+        if 0 <= page_idx < len(self.covers):
+            self._lazy_load_covers_around(page_idx)
 
         # Only trigger when the carousel float position essentially reaches the target page
-        if abs(pos - idx) > 0.001:
+        if abs(pos - page_idx) > 0.001:
             return
 
-        active_page = carousel.get_nth_page(idx)
+        active_page = carousel.get_nth_page(page_idx)
 
         try:
-            new_idx = self.covers.index(active_page)
+            page_idx = self.covers.index(active_page)
         except ValueError:
             return
 
-        if new_idx != self.player.current_queue_index:
+        queue_idx = self._cover_offset + page_idx
+        if queue_idx != self.player.current_queue_index:
             self._ignore_page_change = True
 
-            if 0 <= new_idx < len(self.player.queue):
+            if 0 <= queue_idx < len(self.player.queue):
 
                 def _do_jump(jump_idx):
                     cur = self.player.current_queue_index
@@ -871,4 +853,4 @@ class ExpandedPlayer(Gtk.Box):
                     self.player.emit("state-changed", "queue-updated")
                     return False
 
-                GLib.idle_add(_do_jump, new_idx)
+                GLib.idle_add(_do_jump, queue_idx)

--- a/src/ui/expanded_player.py
+++ b/src/ui/expanded_player.py
@@ -5,8 +5,8 @@ from ui.queue_panel import QueuePanel
 from ui.widgets.lyrics_view import LyricsView
 
 
-MAX_CAROUSEL_COVERS = 31
-CAROUSEL_PRELOAD_RADIUS = 5
+MAX_CAROUSEL_COVERS = 17
+CAROUSEL_PRELOAD_RADIUS = 3
 
 
 class ExpandedPlayer(Gtk.Box):

--- a/src/ui/utils.py
+++ b/src/ui/utils.py
@@ -101,19 +101,18 @@ def invalidate_is_online_cache():
     with _IS_ONLINE_LOCK:
         _IS_ONLINE_STATE["last_probe"] = 0.0
 
-# Bounded LRU Cache to prevent memory leaks (max 100 images). The cache is
+# Bounded LRU Cache to prevent memory leaks. The cache is
 # read/written by multiple worker threads and the main thread, so every
 # mutation is serialized through IMG_CACHE_LOCK — concurrent check-then-modify
 # sequences were corrupting LRU state and evicting pixbufs that other threads
 # were still wiring up into textures.
 IMG_CACHE = collections.OrderedDict()
-# Each cached pixbuf is up to MAX_CACHED_DIM² × 4 bytes. At the old 1600/100
-# settings the cache could pin ~1 GB by itself. The largest on-screen cover
-# is the full-window cover view, which is comfortably served by 1024 even on
-# HiDPI; song-row thumbnails are 56px. Keeping headroom for ~64 covers at
-# 1024² × 4 B ≈ 4 MB each → ~256 MB hard ceiling.
-MAX_CACHE_SIZE = 64
-MAX_CACHED_DIM = 1024
+# Each cached pixbuf is up to MAX_CACHED_DIM² × 4 bytes. A 64-entry cache at
+# 1024px can pin ~256 MB by itself after playlist/queue browsing. Keep enough
+# warm artwork for the current view and nearby tracks without letting decoded
+# covers dominate the process footprint.
+MAX_CACHE_SIZE = 24
+MAX_CACHED_DIM = 768
 IMG_CACHE_LOCK = threading.Lock()
 
 # Bounded executor for image fetches. Each row's `load_url` used to spawn a
@@ -140,12 +139,11 @@ def _get_fetch_executor():
     with _FETCH_EXECUTOR_LOCK:
         if _FETCH_EXECUTOR is None:
             from concurrent.futures import ThreadPoolExecutor
-            # 4 workers keeps the pipeline saturated for image fetches (which
-            # release the GIL during decode + SSL) without putting so many
-            # Python-wrapper threads on the GIL that the UI thread starves
-            # waiting its turn during a heavy bind storm.
+            # Keep decode concurrency low: GdkPixbuf/PIL bursts can otherwise
+            # briefly allocate hundreds of MB while several covers decode and
+            # downscale at the same time.
             _FETCH_EXECUTOR = ThreadPoolExecutor(
-                max_workers=4, thread_name_prefix="muse-img"
+                max_workers=2, thread_name_prefix="muse-img"
             )
     return _FETCH_EXECUTOR
 
@@ -310,6 +308,24 @@ def cache_pixbuf(url, pixbuf):
         IMG_CACHE[url] = pixbuf
         if len(IMG_CACHE) > MAX_CACHE_SIZE:
             IMG_CACHE.popitem(last=False)
+
+
+def decode_pixbuf_bounded(data, max_dim=MAX_CACHED_DIM):
+    """Decode image bytes with a hard dimension cap applied during load."""
+    loader = GdkPixbuf.PixbufLoader()
+
+    def _on_size_prepared(loader, width, height):
+        if width <= 0 or height <= 0:
+            return
+        if width <= max_dim and height <= max_dim:
+            return
+        scale = max_dim / max(width, height)
+        loader.set_size(max(1, int(width * scale)), max(1, int(height * scale)))
+
+    loader.connect("size-prepared", _on_size_prepared)
+    loader.write(data)
+    loader.close()
+    return loader.get_pixbuf()
 
 
 def get_high_res_url(url, target_size=None):
@@ -834,12 +850,32 @@ class AsyncImage(Gtk.Image):
         self._is_placeholder = True
         self.url = url
         self.circular = circular
+        self.video_id = None
+        self._pending_fetch = None
+        self._map_handler_id = None
+        self.connect("destroy", self._on_destroy)
         # Remember the desktop size so set_compact() can restore it
         # when compact mode toggles off. Mirrors AsyncPicture.target_size.
         self._base_size = self.target_w
 
         if url:
             self.load_url(url)
+
+    def _on_destroy(self, *_):
+        self._pending_fetch = None
+        self.url = None
+        self.video_id = None
+        handler_id = getattr(self, "_map_handler_id", None)
+        if handler_id:
+            try:
+                self.disconnect(handler_id)
+            except Exception:
+                pass
+            self._map_handler_id = None
+        try:
+            self.clear()
+        except Exception:
+            pass
 
     def set_compact(self, compact):
         """Switch between desktop and mobile sizing. Only applies to
@@ -990,22 +1026,9 @@ class AsyncImage(Gtk.Image):
                         data = resp.content
                         write_thumb_cache(url, data)
 
-                loader = GdkPixbuf.PixbufLoader()
-                loader.write(data)
-                loader.close()
-                pixbuf = loader.get_pixbuf()
+                pixbuf = decode_pixbuf_bounded(data)
 
                 if pixbuf:
-                    w = pixbuf.get_width()
-                    h = pixbuf.get_height()
-                    if w > MAX_CACHED_DIM or h > MAX_CACHED_DIM:
-                        scale = MAX_CACHED_DIM / max(w, h)
-                        pixbuf = pixbuf.scale_simple(
-                            int(w * scale),
-                            int(h * scale),
-                            GdkPixbuf.InterpType.BILINEAR,
-                        )
-
                     cache_pixbuf(url, pixbuf)
 
             if pixbuf:
@@ -1143,6 +1166,9 @@ class AsyncPicture(Gtk.Picture):
         self.url = url
         self.video_id = None
         self._is_placeholder = True
+        self._pending_fetch = None
+        self._map_handler_id = None
+        self.connect("destroy", self._on_destroy)
 
         # Constrain the picture widget to target_size so it doesn't
         # request more space when a non-square texture is loaded
@@ -1161,6 +1187,22 @@ class AsyncPicture(Gtk.Picture):
             self._is_placeholder = True
             if url:
                 self.load_url(url)
+
+    def _on_destroy(self, *_):
+        self._pending_fetch = None
+        self.url = None
+        self.video_id = None
+        handler_id = getattr(self, "_map_handler_id", None)
+        if handler_id:
+            try:
+                self.disconnect(handler_id)
+            except Exception:
+                pass
+            self._map_handler_id = None
+        try:
+            self.set_paintable(None)
+        except Exception:
+            pass
 
     def do_measure(self, orientation, for_size):
         """Clamp natural size so the texture doesn't inflate the parent.
@@ -1315,24 +1357,11 @@ class AsyncPicture(Gtk.Picture):
                     data = resp.content
                     write_thumb_cache(url, data)
 
-            loader = GdkPixbuf.PixbufLoader()
-            loader.write(data)
-            loader.close()
-            pixbuf = loader.get_pixbuf()
+            pixbuf = decode_pixbuf_bounded(data)
 
             if pixbuf:
                 w = pixbuf.get_width()
                 h = pixbuf.get_height()
-
-                if w > MAX_CACHED_DIM or h > MAX_CACHED_DIM:
-                    scale = MAX_CACHED_DIM / max(w, h)
-                    pixbuf = pixbuf.scale_simple(
-                        int(w * scale),
-                        int(h * scale),
-                        GdkPixbuf.InterpType.BILINEAR,
-                    )
-                    w = pixbuf.get_width()
-                    h = pixbuf.get_height()
 
                 # Cache the high-res version BEFORE potential thumbnail downscaling
                 cache_pixbuf(url, pixbuf)

--- a/src/ui/utils.py
+++ b/src/ui/utils.py
@@ -107,13 +107,29 @@ def invalidate_is_online_cache():
 # sequences were corrupting LRU state and evicting pixbufs that other threads
 # were still wiring up into textures.
 IMG_CACHE = collections.OrderedDict()
-# Each cached pixbuf is up to MAX_CACHED_DIM² × 4 bytes. A 64-entry cache at
-# 1024px can pin ~256 MB by itself after playlist/queue browsing. Keep enough
-# warm artwork for the current view and nearby tracks without letting decoded
-# covers dominate the process footprint.
-MAX_CACHE_SIZE = 24
-MAX_CACHED_DIM = 768
+# Each cached pixbuf is up to MAX_CACHED_DIM² × 4 bytes. Keep the in-process
+# cache intentionally small; disk cache still makes revisiting artwork cheap
+# without pinning decoded RGBA buffers in RAM.
+MAX_CACHE_SIZE = 12
+MAX_CACHED_DIM = 512
 IMG_CACHE_LOCK = threading.Lock()
+_LAST_MALLOC_TRIM = 0.0
+_MALLOC_TRIM_LOCK = threading.Lock()
+
+
+def _trim_process_heap(min_interval=5.0):
+    """Return freed glibc heap pages to the OS after large image evictions."""
+    global _LAST_MALLOC_TRIM
+    now = time.monotonic()
+    with _MALLOC_TRIM_LOCK:
+        if now - _LAST_MALLOC_TRIM < min_interval:
+            return
+        _LAST_MALLOC_TRIM = now
+    try:
+        import ctypes
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except Exception:
+        pass
 
 # Bounded executor for image fetches. Each row's `load_url` used to spawn a
 # fresh `threading.Thread`, which costs ~1-2ms apiece — when 25 rows bind at
@@ -306,8 +322,12 @@ def cache_pixbuf(url, pixbuf):
             IMG_CACHE.move_to_end(url)
             return
         IMG_CACHE[url] = pixbuf
+        evicted = False
         if len(IMG_CACHE) > MAX_CACHE_SIZE:
             IMG_CACHE.popitem(last=False)
+            evicted = True
+    if evicted:
+        _trim_process_heap()
 
 
 def decode_pixbuf_bounded(data, max_dim=MAX_CACHED_DIM):


### PR DESCRIPTION
Stacked on #67. Review after that PR.

Changes on top:
- Smaller decoded artwork cache.
- Smaller expanded-player carousel window.
- Smaller cover-effect caches and blurred-cover output.
- Throttled malloc_trim after image cache eviction.

Local result:
- Playback RSS dropped from roughly 700-800 MB to roughly 380 MB after the full memory patch set.

Validation:
- Compiled all Python files with python3.
