### PR TITLE
flake: add default package, devShell reuses package inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ yay -S mixtapes-git
 
 ### Nix
 
-A Nix flake is available. See [setup instructions](https://github.com/m-obeid/Muse/pull/2#issue-3965386248).
+```
+nix run github:m-obeid/Mixtapes       # run directly from GitHub
+nix run                               # run from local checkout
+nix develop                           # enter dev shell
+```
 
 ### From Source
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,35 +8,80 @@
 
   outputs = { self, nixpkgs, utils }:
     utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { inherit system; }; in {
-      devShell = with pkgs;
-         mkShell {
-            packages = [ 
-              # UI
-              gtk4
-              libadwaita
-              webkitgtk_6_0
-              # GStreamer
-              gst_all_1.gstreamer
-              gst_all_1.gst-plugins-base
-              gst_all_1.gst-plugins-good
-              gst_all_1.gst-plugins-bad
-              gst_all_1.gst-plugins-ugly
-              # Python dependencies
-              python314
-              python314Packages.pygobject3
-              python314Packages.ytmusicapi
-              python314Packages.yt-dlp
-              python314Packages.yt-dlp-ejs
-              python314Packages.requests
-              python314Packages.mutagen
-              python314Packages.mprisify
-              nodejs
-            ];
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        version = pkgs.lib.pipe (self + "/com.pocoguy.Muse.metainfo.xml") [
+          builtins.readFile
+          (builtins.match ".*<releases>[^<]*<release version=\"([^\"]+)\"[^>]*>.*")
+          builtins.head
+        ];
+
+        lines = pkgs.lib.pipe (self + "/requirements.txt") [
+          builtins.readFile
+          (builtins.split "\n")
+          (builtins.filter (x: builtins.isString x && x != ""))
+        ];
+
+        pipName = line: let
+          m = builtins.match "([a-zA-Z][a-zA-Z0-9._-]*).*" line;
+        in
+          if m == null then null else builtins.head m;
+
+        pipToNix = {
+          PyGObject = "pygobject3";
+          Pillow = "pillow";
+          StrEnum = "strenum";
+        };
+
+        nixAttr = name: pipToNix.${name} or (pkgs.lib.strings.toLower name);
+
+        pythonDeps = pkgs.lib.pipe lines [
+          (builtins.map pipName)
+          (builtins.filter (n: n != null))
+          (builtins.map (name: pkgs.python314Packages.${nixAttr name} or null))
+          (builtins.filter (d: d != null))
+        ];
+
+        pythonEnv = pkgs.python314.withPackages (ps: pythonDeps);
+
+        mixtapes = pkgs.stdenv.mkDerivation {
+          pname = "mixtapes";
+          inherit version;
+          src = self;
+
+          nativeBuildInputs = [ pkgs.makeWrapper pkgs.wrapGAppsHook3 ];
+
+          buildInputs = [
+            pkgs.gtk4
+            pkgs.libadwaita
+            pkgs.webkitgtk_6_0
+            pkgs.gobject-introspection
+            pkgs.gst_all_1.gstreamer
+            pkgs.gst_all_1.gst-plugins-base
+            pkgs.gst_all_1.gst-plugins-good
+            pkgs.gst_all_1.gst-plugins-bad
+            pkgs.gst_all_1.gst-plugins-ugly
+            pythonEnv
+          ];
+
+          installPhase = ''
+            mkdir -p $out/bin $out/share/mixtapes
+            cp -r src/* $out/share/mixtapes/
+            makeWrapper ${pythonEnv}/bin/python $out/bin/mixtapes \
+              --add-flags "$out/share/mixtapes/main.py"
+          '';
+        };
+      in {
+        packages.default = mixtapes;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ mixtapes ];
+          packages = [ pkgs.nodejs ];
           shellHook = ''
             python --version
           '';
-         };
+        };
       }
-   );
+    );
 }


### PR DESCRIPTION
This PR refactors the flake so that it provides an actual package, that way `nix run` is enough to run the app.

The flake inputs have also been updated as the current version fails to run (outdated `yt-dlp`).

As this flake doesn't seem to be a first-class citizen in this repo (which is fine), I took the liberty to implement some tricks that let us automatically follow small changes to the app's dependencies and version number so that the package keeps working without much maintenance on the nix side of things.