### PR TITLE
Queue rebuild/behavior fix

### DIFF
--- a/src/player/player.py
+++ b/src/player/player.py
@@ -799,7 +799,6 @@ class Player(GObject.Object):
             self.current_queue_index = index
             self._play_current_index()
             self._maybe_extend_infinite()
-            self.emit("state-changed", "queue-updated")
 
     def next(self):
         if self.current_queue_index + 1 < len(self.queue):
@@ -826,8 +825,6 @@ class Player(GObject.Object):
             else:
                 self.stop()  # End of queue
                 self.current_queue_index = -1
-
-        self.emit("state-changed", "queue-updated")
 
     # ── Gapless handlers ──────────────────────────────────────────────────────
 
@@ -958,7 +955,6 @@ class Player(GObject.Object):
                 self.mpris_events.on_player_all()
             except Exception as e:
                 print(f"mpris ERROR: {e}")
-        self.emit("state-changed", "queue-updated")
 
         # Top up the cache for whatever comes after this newly-current track.
         threading.Thread(

--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -885,6 +885,13 @@ class PlaylistPage(Adw.Bin):
         if not is_online() and not self.player.download_manager.is_downloaded(video_id):
             return
 
+        # If playlist is currently queued, jump to track
+        if self.player.queue_source_id == self.playlist_id:
+            for i, t in enumerate(self.player.queue):
+                if t.get("videoId") == video_id:
+                    self.player.play_queue_index(i)
+            return
+
         # Use the same queue the big Play button uses so playing a track
         # respects the user's chosen sort + direction. Falling back to
         # `original_tracks` unconditionally would always queue the


### PR DESCRIPTION
2 commits

1) Removed unnecessary emitting of "queue-updated" when only the queue's index changes. This prevents a whole queue rebuild every time the song changes in the same queue. Fixes observed memory leak in #79, as apparently queue rebuilds have a memory leak, so eliminating most queue rebuilding eliminates much of the current memory leaks. Memory will no longer be leaked for skips/transitions in same playlist.

2) Added feature: when a song in a playlist is clicked and that playlist is already currently queued, simply jump to that song in the queue instead of reordering the queue based off the current ordering/direction of playlist. 2 notable implications: (a) queue will no longer rebuild when a song is clicked in playlist, helping address memory leaks in 1), and (b) if the queue was shuffled, clicking a song in playlist will no longer erases that shuffle (this behavior felt very unnatural). 