### PR TITLE
fix: remove selectable and activatable from songs row

### DIFF
--- a/src/ui/pages/playlist.py
+++ b/src/ui/pages/playlist.py
@@ -471,6 +471,9 @@ class PlaylistPage(Adw.Bin):
         bin_widget.add_css_class("list-item-bin")
         list_item.set_child(bin_widget)
 
+        list_item.set_selectable(False)
+        list_item.set_activatable(False)
+
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         row.set_hexpand(True)
         row.add_css_class("song-row")
@@ -634,14 +637,10 @@ class PlaylistPage(Adw.Bin):
             return
 
         if type(item).__name__ == "HeaderItem":
-            list_item.set_selectable(False)
-            list_item.set_activatable(False)
             bin_widget.set_child(self.header_container)
             return
 
         bin_widget.set_child(bin_widget._lv_track_ui)
-        list_item.set_selectable(True)
-        list_item.set_activatable(True)
 
         row = bin_widget._lv_track_ui
         t = item.data
@@ -767,8 +766,6 @@ class PlaylistPage(Adw.Bin):
             row.set_sensitive(False)
             row.set_opacity(0.4)
         else:
-            list_item.set_activatable(has_id)
-            list_item.set_selectable(has_id)
             row.set_sensitive(has_id)
             row.set_opacity(1.0)
 


### PR DESCRIPTION
This PR removes the activatable and selectable state from playlist's listview items. These states aren't needed because the songs row in the listview is built with their own buttons and activate signal; the listview items are just containers for those buttons, hence shouldn't be activatable or selectable by semantics.

This indirectly fixes my double highlight on hover with my GTK theme (which applies hover animation to `.activatable` class). It should also fix other GTK themes with similar theming conventions.

Before:
<img width="1559" height="161" alt="image" src="https://github.com/user-attachments/assets/9f0b62e5-51e7-4f54-b8e4-d54c787861c6" />

After:
<img width="1528" height="140" alt="image" src="https://github.com/user-attachments/assets/6b8ffe14-b7af-4d81-b9d4-83d9f1323fdd" />
